### PR TITLE
GO-219 Reindex message thread only if searchable fields on message changed

### DIFF
--- a/app/jobs/searchable/reindex_message_thread_job.rb
+++ b/app/jobs/searchable/reindex_message_thread_job.rb
@@ -16,6 +16,6 @@ class Searchable::ReindexMessageThreadJob < ApplicationJob
   def perform(message_thread)
     return if message_thread.nil?
 
-    ::Searchable::MessageThread.index_record(message_thread)
+    ::Searchable::Indexer.index_message_thread(message_thread)
   end
 end

--- a/app/lib/event_bus.rb
+++ b/app/lib/event_bus.rb
@@ -29,7 +29,9 @@ EventBus.reset!
 EventBus.subscribe_job :message_thread_created, Automation::MessageThreadCreatedJob
 EventBus.subscribe_job :message_created, Automation::MessageCreatedJob
 EventBus.subscribe :message_changed, ->(message) {
-  Searchable::ReindexMessageThreadJob.perform_later(message.thread) if message.changed_searchable_fields?
+  if Searchable::Indexer.message_searchable_fields_changed?(message)
+    Searchable::ReindexMessageThreadJob.perform_later(message.thread)
+  end
 }
 EventBus.subscribe_job :message_thread_changed, Searchable::ReindexMessageThreadJob
 EventBus.subscribe :message_thread_tag_changed,

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -29,12 +29,6 @@ class Message < ApplicationRecord
 
   delegate :tenant, to: :thread
 
-  SEARCHABLE_FIELDS = [
-    { name: :title, formatter: :string },
-    { name: :sender_name, formatter: :string },
-    { name: :html_visualization, formatter: :html_string },
-  ]
-
   after_create_commit ->(message) { EventBus.publish(:message_created, message) }
   after_commit ->(message) { EventBus.publish(:message_changed, message) }
 
@@ -61,25 +55,5 @@ class Message < ApplicationRecord
 
   def authorized?
     metadata["delivery_notification"] && metadata["authorized"] == true
-  end
-
-  def to_searchable_string
-    SEARCHABLE_FIELDS.map do |searchable_field|
-      field_name, formatter = searchable_field.fetch_values(:name, :formatter)
-      value = public_send(field_name)
-
-      case formatter
-        when :string
-          Searchable::IndexHelpers.searchable_string(value)
-        when :html_string
-          Searchable::IndexHelpers.html_to_searchable_string(value)
-        else
-          throw :unsupported_searchable_formatter
-      end
-    end.compact.join(' ')
-  end
-
-  def changed_searchable_fields?
-    SEARCHABLE_FIELDS.any?{ |field| saved_changes.key?(field[:name].to_s) }
   end
 end

--- a/app/models/searchable/indexer.rb
+++ b/app/models/searchable/indexer.rb
@@ -1,0 +1,44 @@
+class Searchable::Indexer
+  MESSAGE_SEARCHABLE_FIELDS = [
+    { name: :title, formatter: :string },
+    { name: :sender_name, formatter: :string },
+    { name: :html_visualization, formatter: :html_string },
+  ]
+
+  def self.index_message_thread(message_thread)
+    record = ::Searchable::MessageThread.find_or_initialize_by(message_thread_id: message_thread.id)
+    record.title = Searchable::IndexHelpers.searchable_string(message_thread.title)
+    record.tag_ids = message_thread.tags.map(&:id)
+    record.tag_names = Searchable::IndexHelpers.searchable_string(message_thread.tags.map(&:name).join(' ').gsub(/[:\/]/, " "))
+    record.content = message_thread.messages.map { |message| message_to_searchable_string(message) }.join(' ')
+    record.last_message_delivered_at = message_thread.last_message_delivered_at
+    record.tenant_id = message_thread.folder.box.tenant_id
+    record.box_id = message_thread.folder.box_id
+
+    record.save!
+  end
+
+  def self.message_to_searchable_string(message)
+    record_to_searchable_string(message, MESSAGE_SEARCHABLE_FIELDS)
+  end
+
+  def self.record_to_searchable_string(record, searchable_fields)
+    searchable_fields.map do |searchable_field|
+      field_name, formatter = searchable_field.fetch_values(:name, :formatter)
+      value = record.public_send(field_name)
+
+      case formatter
+        when :string
+          Searchable::IndexHelpers.searchable_string(value)
+        when :html_string
+          Searchable::IndexHelpers.html_to_searchable_string(value)
+        else
+          throw :unsupported_searchable_formatter
+      end
+    end.compact.join(' ')
+  end
+
+  def self.message_searchable_fields_changed?(message)
+    MESSAGE_SEARCHABLE_FIELDS.any?{ |field| message.saved_changes.key?(field[:name].to_s) }
+  end
+end

--- a/app/models/searchable/message_thread.rb
+++ b/app/models/searchable/message_thread.rb
@@ -52,19 +52,6 @@ class Searchable::MessageThread < ApplicationRecord
     [ids, next_cursor]
   end
 
-  def self.index_record(message_thread)
-    record = ::Searchable::MessageThread.find_or_initialize_by(message_thread_id: message_thread.id)
-    record.title = Searchable::IndexHelpers.searchable_string(message_thread.title)
-    record.tag_ids = message_thread.tags.map(&:id)
-    record.tag_names = Searchable::IndexHelpers.searchable_string(message_thread.tags.map(&:name).join(' ').gsub(/[:\/]/, " "))
-    record.content = message_thread.messages.map { |message| message.to_searchable_string }.join(' ')
-    record.last_message_delivered_at = message_thread.last_message_delivered_at
-    record.tenant_id = message_thread.folder.box.tenant_id
-    record.box_id = message_thread.folder.box_id
-
-    record.save!
-  end
-
   def self.reindex_with_tag_id(tag_id)
     Searchable::MessageThread.select(:id, :message_thread_id).where("tag_ids && ARRAY[?]", [tag_id]).find_each do |searchable_mt|
       Searchable::ReindexMessageThreadJob.perform_later(::MessageThread.find(searchable_mt.message_thread_id))
@@ -72,6 +59,6 @@ class Searchable::MessageThread < ApplicationRecord
   end
 
   def self.reindex_all
-    ::MessageThread.includes(:tags, :messages, folder: :box).find_each { |mt| index_record(mt) }
+    ::MessageThread.includes(:tags, :messages, folder: :box).find_each { |mt| ::Searchable::Indexer.index_message_thread(mt) }
   end
 end


### PR DESCRIPTION
Toto riesi len ten problem, ze ked sa otvaral thread, tak sa sprava oznacuje ako precitana. Toto spustalo reindexaciu celeho threadu. Len som vytiahol fieldy a checkuje sa teraz, ci sa zmenili, a len ak ano, tak sa spusti reindex.

Dalsie veci v searchi budu v samostatnom PR