### PR TITLE
Fix Govbox::DestroyBoxDataJob

### DIFF
--- a/app/jobs/govbox/destroy_box_data_job.rb
+++ b/app/jobs/govbox/destroy_box_data_job.rb
@@ -3,7 +3,8 @@ module Govbox
     queue_as :default
 
     def perform(box_id)
-      Govbox::ApiConnection.find_by(box_id: box_id).destroy
+      Govbox::ApiConnection.find_by(box_id: box_id)&.destroy
+      Govbox::Folder.where(box_id: box_id).find_each { |govbox_folder| govbox_folder.messages.in_batches(of: 50).destroy_all }
       Govbox::Folder.where(box_id: box_id).destroy_all
     end
   end


### PR DESCRIPTION
Pri mazani vacsieho boxu v PROD sa ukazal problem s mazanim govbox priecinkov spolu s ich vsetkymi spravami naraz.