### PR TITLE
GO-170 Add more error messages to autogram controller to support also Firefox, Safari

### DIFF
--- a/app/javascript/controllers/autogram_controller.js
+++ b/app/javascript/controllers/autogram_controller.js
@@ -74,7 +74,7 @@ export default class extends Controller {
           }).then(function () {
             resolve();
           }).catch(function (err) {
-            if (err.message === "Failed to fetch") {
+            if (["Failed to fetch", "NetworkError when attempting to fetch resource.", "Load failed"].includes(err.message)) {
               alert("Spustite aplikáciu autogram.")
             }
             else {


### PR DESCRIPTION
Otestovane na Chrome, Firefox, Safari, aby aplikacia hodila spravnu error hlasku, ak nie je spusteny autogram.