### PR TITLE
Remove lazy loading from modal contents

### DIFF
--- a/app/components/common/tag_selector_component.html.erb
+++ b/app/components/common/tag_selector_component.html.erb
@@ -23,7 +23,7 @@
                               class: "grow border-0 bg-transparent py-1.5 pl-1 text-gray-900 placeholder:text-gray-400 focus:ring-0 sm:text-sm sm:leading-6" %>
       <% end %>
       <div class="w-full">
-        <%= tag.turbo_frame id: "tag-selector-popup", class: "w-100", loading: :lazy, src: search_available_tags_message_thread_path(@message_thread) %>
+        <%= tag.turbo_frame id: "tag-selector-popup", class: "w-100", src: search_available_tags_message_thread_path(@message_thread) %>
       </div>
     </div>
     <%= render Common::ModalActionsComponent.new %>

--- a/app/components/layout/box_selector_component.html.erb
+++ b/app/components/layout/box_selector_component.html.erb
@@ -16,7 +16,7 @@
     </button>
   <% end %>
   <% component.with_modal_content do %>
-    <%= tag.turbo_frame id: 'box-selector-popup', loading: :lazy, src: get_selector_boxes_path %>
+    <%= tag.turbo_frame id: 'box-selector-popup', src: get_selector_boxes_path %>
     <%= render Common::ModalActionsComponent.new %>
   <% end %>
 <% end %>


### PR DESCRIPTION
- Lazy loading sposobuje preblik pri otvoreni modalu. Lebo najprv sa prida modal, a potom sa zmeni obsah contentu, ked sa doloaduje obsah. Bez lazy je to hned.