### PR TITLE
GO-306 Add inbox scope to messages

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -17,6 +17,7 @@
 #  delivered_at                                :datetime         not null
 #  import_id                                   :integer
 #  author_id                                   :integer
+#  type                                        :string
 #  created_at                                  :datetime         not null
 #  updated_at                                  :datetime         not null
 
@@ -36,7 +37,7 @@ class Message < ApplicationRecord
   delegate :tenant, to: :thread
 
   scope :outbox, -> { where(outbox: true) }
-  scope :inbox, -> { where.not(outbox: true) }
+  scope :inbox, -> { where.not(outbox: true).where(type: nil).or(self.where.not(type: "MessageDraft")) }
 
   after_create_commit ->(message) { EventBus.publish(:message_created, message) }
   after_update_commit ->(message) { EventBus.publish(:message_changed, message) }


### PR DESCRIPTION
Mergli sme do mainu kod, ktory spolieha na to, ze vieme rozlisit ktore spravy su inboxove. Takze chceme pridat inbox scope k Message.