### PR TITLE
GO-320 Fix DOMNodeInserted event listener on drafts

### DIFF
--- a/app/components/message_thread_component.html.erb
+++ b/app/components/message_thread_component.html.erb
@@ -12,6 +12,8 @@
         <%= render MessageComponent.new(message: message, mode: :thread_view) %>
       <% end %>
     <% end %>
-    <div id="new_message_placeholder" is="turbo-frame"></div>
+    <div id="new_drafts">
+      <div id="new_message_placeholder" is="turbo-frame"></div>
+    </div>
   </div>
 </div>

--- a/app/javascript/controllers/message_drafts_controller.js
+++ b/app/javascript/controllers/message_drafts_controller.js
@@ -3,8 +3,8 @@ import { post, patch } from '@rails/request.js'
 
 export default class extends Controller {
   connect() {
-    const messagesElement = document.getElementById("messages")
-    messagesElement.addEventListener("DOMNodeInserted", this.showLastMessageDraft);
+    const newDraftsElement = document.getElementById("new_drafts")
+    newDraftsElement.addEventListener("DOMNodeInserted", this.showLastMessageDraft);
   }
 
   async update() {


### PR DESCRIPTION
DOMNodeInserted event sa vyvolal aj pri zbaleni/rozbaleni spravy. Nic lepsie som zatial nevymyslela ako vytvorit zvlast element pre nove drafty a hodit listener iba na neho.