### PR TITLE
GO-359 Fix race condition in reindex job

### DIFF
--- a/app/jobs/searchable/reindex_message_thread_job.rb
+++ b/app/jobs/searchable/reindex_message_thread_job.rb
@@ -6,7 +6,12 @@ class Searchable::ReindexMessageThreadJob < ApplicationJob
   good_job_control_concurrency_with(
     # Maximum number of unfinished jobs to allow with the concurrency key
     # Can be an Integer or Lambda/Proc that is invoked in the context of the job
-    total_limit: 1,
+    total_limit: 2,
+
+    # Maximum number of jobs with the concurrency key to be
+    # concurrently performed (excludes enqueued jobs)
+    # Can be an Integer or Lambda/Proc that is invoked in the context of the job
+    perform_limit: 1,
 
     key: -> { "Searchable::ReindexMessageThreadJob-#{arguments.first}" }
   )


### PR DESCRIPTION
- Aktualne je mozne, ze sa thread meni prave vtedy, ak sa reindexuje do searchu
- Ak bezi reindex jobu, tak sa nemoze zaradit nova reindexacia do fronty, cize vznika moznost, ze search nema indexovany skutocny stav databazy
- Toto tento stav fixuje

## Dlhsie vysvetlenie:
(dostupne aj ako video, len to ma viac ako 10 MB, tak to sem mozem dat len ako link do slacku: https://slovensko-digital.slack.com/archives/C054K219JLX/p1700481079765089)
- cele je to o tom, ze sa chceme sa vyhnut race condition, kedy pri jobe, ktory cita zmeny z DB sa stav databazy meni, a uz beziaci job nemusi zachytil vsetko. preto potrebujeme aby zbehol dalsi, ktory novy stav zachyti.

### Slovnik:
- identicky job = job s rovnakym concurrency key.

### Moznosti
#### Idealny scenar by bol takyto
- identicky job sa zaradi do fronty len vtedy, ak:
  - vo fronte taky este nie je
  - ak taky job vo fronte sice je, ale uz vykonavania.

#### Ako funguje GJ s `total_limit`?
- ide to presne podla toho, co je v komente
  - _Maximum number of unfinished jobs to allow with the concurrency key_
- prakticky to znamena, ze medzi unfinished sa pocita aj taky job, ktory prave bezi. lebo kontroluje sa iba toto
`SELECT COUNT(*) FROM "good_jobs" WHERE "good_jobs"."concurrency_key" = $1 AND "good_jobs"."finished_at" IS NULL` < `total_limit`

- samotne navysenie `total_limit` nepomoze, lebo identicke joby sa mozy vykonavat paralelne (cize mozu oba bezat) a mame znova tu istu race condition.

#### Riesenie `perform_limit: 1, total_limit: 2`
- GJ umoznuje nastavit `perform_limit` a tym a garantovat, ze sa vykonava max dany pocet identickych jobov
  - _Maximum number of jobs with the concurrency key to be concurrently performed_
- v kombinaci s `total_limit = 2`, vieme povedat, ze stavy budu len dva:
  - bud oba identicke joby cakaju na vykonanie (su zaradene, ale este nebezia)
  - jeden sa vykonava, druhy caka

- tym padom, by sme sa vyhli race condition, lebo bude garantovane, ze sa identicky job zaradi do fronty. zaroven by sme nepridavali dalsie joby do fronty, ak uz tam identicky job je.

### Zdroje
- https://github.com/bensheldon/good_job#concurrency-controls