### PR TITLE
GO-353 Update Drafts Tag system name

### DIFF
--- a/db/migrate/20231123085142_update_drafts_tag_system_name.rb
+++ b/db/migrate/20231123085142_update_drafts_tag_system_name.rb
@@ -1,0 +1,5 @@
+class UpdateDraftsTagSystemName < ActiveRecord::Migration[7.0]
+  def change
+    Tag.where(system_name: "Drafts").update_all(system_name: "draft")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_18_103512) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_23_085142) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
Este maly fix. Zmenili sme hodnotu v Tag::DRAFT_SYSTEM_NAME, ale neupdatli systemovy nazov existujucich draftovych tagov.