### PR TITLE
GO-2 Update Govbox::DownloadMessageJob

### DIFF
--- a/app/jobs/govbox/download_message_job.rb
+++ b/app/jobs/govbox/download_message_job.rb
@@ -19,9 +19,7 @@ module Govbox
         govbox_message.payload = raw_message
       end
 
-      processed_message = ::Message.where(uuid: govbox_message.message_id).joins(:thread).where(thread: { box_id: govbox_message.box.id }).take
-
-      ProcessMessageJob.perform_later(govbox_message) unless processed_message
+      ProcessMessageJob.perform_later(govbox_message)
     end
   end
 end

--- a/app/jobs/govbox/download_message_job.rb
+++ b/app/jobs/govbox/download_message_job.rb
@@ -8,17 +8,20 @@ module Govbox
 
       raise "Unable to fetch folder messages" if response_status != 200
 
-      govbox_message = govbox_folder.messages.create!(
-        edesk_message_id: raw_message["id"],
-        message_id: raw_message["message_id"],
-        correlation_id: raw_message["correlation_id"],
-        delivered_at: Time.parse(raw_message["delivered_at"]),
-        edesk_class: raw_message["class"],
-        body: raw_message["original_xml"],
-        payload: raw_message
-      )
+      govbox_message = govbox_folder.messages.find_or_create_by!(
+        edesk_message_id: raw_message["id"]
+      ) do |govbox_message|
+        govbox_message.message_id = raw_message["message_id"]
+        govbox_message.correlation_id = raw_message["correlation_id"]
+        govbox_message.delivered_at = Time.parse(raw_message["delivered_at"])
+        govbox_message.edesk_class = raw_message["class"]
+        govbox_message.body = raw_message["original_xml"]
+        govbox_message.payload = raw_message
+      end
 
-      ProcessMessageJob.perform_later(govbox_message)
+      processed_message = ::Message.where(uuid: govbox_message.message_id).joins(:thread).where(thread: { box_id: govbox_message.box.id }).take
+
+      ProcessMessageJob.perform_later(govbox_message) unless processed_message
     end
   end
 end

--- a/app/jobs/govbox/process_message_job.rb
+++ b/app/jobs/govbox/process_message_job.rb
@@ -7,6 +7,9 @@ module Govbox
     retry_on ::ApplicationRecord::FailedToAcquireLockError, wait: :polynomially_longer, attempts: Float::INFINITY
 
     def perform(govbox_message)
+      processed_message = ::Message.where(uuid: govbox_message.message_id).joins(:thread).where(thread: { box_id: govbox_message.box.id }).take
+      return if processed_message
+
       ActiveRecord::Base.transaction do
         message = Govbox::Message.create_message_with_thread!(govbox_message)
 


### PR DESCRIPTION
Chceme vyriešiť problém, kedy sa súbežne môžu naplánovať 2 rovnaké Govbox::DownloadMessageJobs, vtedy chceme:
- aby sa UPVS správa nevytvorila duplicitne
- aby sa UPVS správa nesprocessovala duplicitne.
