### PR TITLE
GO-12 Fix heading in Signing::SignersRequests::Component

### DIFF
--- a/app/components/signing/signers_requests/component.html.erb
+++ b/app/components/signing/signers_requests/component.html.erb
@@ -1,6 +1,6 @@
 <%= render Common::ModalComponent.new do |modal| %>
   <% modal.with_header do %>
-    Dokumenty na podpis
+    Podpisujúci
   <% end %>
   <% modal.with_modal_content do %>
     <%= form_with url: prepare_message_draft_signature_requests_path(@message_draft) do %>


### PR DESCRIPTION
Pri vybere podpisujucich je nespravny nadpis "Dokumenty na podpis".
Je to matuce hlavne ak sprava ma iba formular (1 objekt), vtedy sa automaticky zvoli iba formular na podpis a pouzivatel sa zobrazi az tato obrazovka:
![image](https://github.com/slovensko-digital/govbox-pro/assets/43437253/0765fc96-cf57-4f0c-a6f3-c172f7b4627d)
