### PR TITLE
Fix GoodJob cron config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,7 @@ module GovboxPro
       }
     end
 
-    config.good_job.cron = {
+    config.good_job.cron['check_messages_mapping'] = {
       check_messages_mapping: {
         cron: "30 7 * * *",  # run every day at 7:30 am
         class: "Govbox::CheckMessagesMappingJob",


### PR DESCRIPTION
Checkovanie mapovania sprav bolo nespravne pridane, co sposobilo prepisanie configu pre sync. 
Navrhujem pridat nejaky check, kedy naposledy zbehol sync schranok, aby sme boli upozorneni na taketo veci.