### PR TITLE
Fix MessageDrafts without template submission

### DIFF
--- a/app/jobs/govbox/submit_message_draft_job.rb
+++ b/app/jobs/govbox/submit_message_draft_job.rb
@@ -10,11 +10,7 @@ class Govbox::SubmitMessageDraftJob < ApplicationJob
   def perform(message_draft, schedule_sync: true, upvs_client: UpvsEnvironment.upvs_client)
     raise "Invalid message!" unless message_draft.valid?(:validate_data)
 
-    all_message_metadata = if message_draft.template&.metadata
-       message_draft.metadata.merge(message_draft.template&.metadata)
-     else
-         message_draft.metadata
-     end
+    all_message_metadata = message_draft.metadata.merge(message_draft.template&.metadata || {})
 
     message_draft_data = {
       sktalk_class: all_message_metadata["sktalk_class"],

--- a/app/jobs/govbox/submit_message_draft_job.rb
+++ b/app/jobs/govbox/submit_message_draft_job.rb
@@ -10,7 +10,11 @@ class Govbox::SubmitMessageDraftJob < ApplicationJob
   def perform(message_draft, schedule_sync: true, upvs_client: UpvsEnvironment.upvs_client)
     raise "Invalid message!" unless message_draft.valid?(:validate_data)
 
-    all_message_metadata = message_draft.metadata.merge(message_draft.template&.metadata)
+    all_message_metadata = if message_draft.template&.metadata
+       message_draft.metadata.merge(message_draft.template&.metadata)
+     else
+         message_draft.metadata
+     end
 
     message_draft_data = {
       sktalk_class: all_message_metadata["sktalk_class"],


### PR DESCRIPTION
Ak su `message_draft.template&.metadata` nil (ked nebola pouzita sablona), tak dostaneme error.