### PR TITLE
GO-63 Do not authorize delivery notification if already marked authorized

### DIFF
--- a/app/jobs/govbox/authorize_delivery_notification_job.rb
+++ b/app/jobs/govbox/authorize_delivery_notification_job.rb
@@ -1,7 +1,8 @@
 class Govbox::AuthorizeDeliveryNotificationJob < ApplicationJob
   def perform(message, upvs_client: UpvsEnvironment.upvs_client)
-    edesk_api = upvs_client.api(message.thread.box).edesk
+    return if message.metadata["authorized"]
 
+    edesk_api = upvs_client.api(message.thread.box).edesk
     success, target_message_id = edesk_api.authorize_delivery_notification(message.metadata["delivery_notification"]["authorize_url"], mode: :sync)
 
     if success


### PR DESCRIPTION
Riesi problem iba ciastocne. Neoznaci aspon uz prevzatu notifikaciu o doruceni za neprevzatu (po vyfailovani jobu), ale stale neriesi problem prevzatia mimo GO a nasledne prebratie v GO medzi zbehnutim syncu. Aby sme vedeli poriesit aj tento problem, ziadala by sa uprava na strane GB API (aby v response bola sprava o tom, ze sa nepodarilo prevziat kvoli tomu, ze uz je pravzata). Aktualne GB API vracia 500, 'Unknown error'.