### PR TITLE
Pass error object to render_bad_request instead of symbol

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -4,7 +4,7 @@ class ApiController < ActionController::API
 
   rescue_from JWT::DecodeError do |error|
     if error.message == 'Nil JSON web token'
-      render_bad_request(:no_credentials)
+      render_bad_request(RuntimeError.new(:no_credentials))
     else
       # key = error.message == 'obo' ? "obo : :credentials
       render_unauthorized(error.message)


### PR DESCRIPTION
Toto som našiel, keď som tento kúsok kódu chcel použiť inde, tak som rovno fixol. V `render_bad_request` sa volá `error.message`, čo na symbole padalo a vracalo 500.