### PR TITLE
Fix MessageDraft.all_metadata method

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -115,7 +115,7 @@ class Message < ApplicationRecord
   end
 
   def all_metadata
-    metadata.merge(template&.metadata)
+    metadata.merge(template&.metadata || {})
   end
 
   def template


### PR DESCRIPTION
Toto sme chceli upratat, tym, ze dame templatu default `{}`. Nezafunguje to vsak v pripade, ak draft nie je vytvoreny z templatu (teda `template` je `nil`).