### PR TITLE
GO-66 Update assigning tags to objects in MessagesAPI

### DIFF
--- a/app/models/signature_requested_from_tag.rb
+++ b/app/models/signature_requested_from_tag.rb
@@ -16,11 +16,6 @@
 #  tenant_id        :bigint           not null
 #
 class SignatureRequestedFromTag < Tag
-  def assign_to_message_object(message_object)
-    super
-    tenant.signature_requested_tag.assign_to_message_object(message_object)
-  end
-
   def assign_to_thread(thread)
     super
     tenant.signature_requested_tag.assign_to_thread(thread)

--- a/app/models/signed_by_tag.rb
+++ b/app/models/signed_by_tag.rb
@@ -16,11 +16,6 @@
 #  tenant_id        :bigint           not null
 #
 class SignedByTag < Tag
-  def assign_to_message_object(message_object)
-    super
-    tenant.signed_tag.assign_to_message_object(message_object)
-  end
-
   def assign_to_thread(thread)
     super
     tenant.signed_tag.assign_to_thread(thread)

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -60,6 +60,10 @@ class Tenant < ApplicationRecord
     signed_tag || raise(ActiveRecord::RecordNotFound, "`SignatureRequestedTag` not found in tenant: #{id}")
   end
 
+  def user_signature_tags
+    tags.where(type: %w[SignatureRequestedFromTag SignedByTag])
+  end
+
   def feature_enabled?(feature)
     raise "Unknown feature #{feature}" unless feature.in? AVAILABLE_FEATURE_FLAGS
 


### PR DESCRIPTION
Chceme povlit pridanie iba  `SignareureRequestedFromTag`s a `SignedByTag`s k MessageObjectom.