### PR TITLE
GO-66 Subscribe for :message_changed event

### DIFF
--- a/app/jobs/drafts/load_content_job.rb
+++ b/app/jobs/drafts/load_content_job.rb
@@ -60,29 +60,8 @@ class Drafts::LoadContentJob < ApplicationJob
   end
   
   def save_form_visualisation(message_draft)
-    upvs_form = Upvs::Form.find_by(
-      identifier: message_draft.metadata["posp_id"],
-      version: message_draft.metadata["posp_version"],
-      message_type: message_draft.metadata["message_type"],
-    )
-    upvs_form_xslt_html = upvs_form&.xslt_html
-
-    return unless upvs_form_xslt_html
-
-    xslt_template = Nokogiri::XSLT(upvs_form_xslt_html)
-
-    if message_draft.form.is_signed?
-      # TODO add unsigned_content method which calls UPVS OdpodpisanieDat endpoint and uncomment
-      # message_draft.update(
-      #   html_visualization: xslt_template.transform(Nokogiri::XML(message_draft.form.unsigned_content)).to_s.gsub('"', '\'')
-      # )
-      #
-      # message_draft.form.update(
-      #   visualizable: true
-      # )
-    else
       message_draft.update(
-        html_visualization: xslt_template.transform(Nokogiri::XML(message_draft.form.content)).to_s.gsub('"', '\'')
+        html_visualization: message_draft.visualization
       )
 
       if message_draft.custom_visualization?
@@ -92,8 +71,7 @@ class Drafts::LoadContentJob < ApplicationJob
 
       message_draft.form.update(
         visualizable: true
-      )
-    end
+      ) if message_draft.html_visualization
   end
 
   delegate :uuid, to: self

--- a/app/lib/event_bus.rb
+++ b/app/lib/event_bus.rb
@@ -37,9 +37,7 @@ EventBus.subscribe :message_thread_changed, ->(thread) {
 }
 
 # reindexing
-EventBus.subscribe :message_changed, ->(message) do
-  Searchable::ReindexMessageThreadJob.perform_later(message.thread.id)
-end
+EventBus.subscribe :message_changed, ->(message) { Searchable::ReindexMessageThreadJob.perform_later(message.thread.id) }
 
 # reindexing on removals
 EventBus.subscribe :tag_renamed, ->(tag) do

--- a/app/lib/event_bus.rb
+++ b/app/lib/event_bus.rb
@@ -37,6 +37,10 @@ EventBus.subscribe :message_thread_changed, ->(thread) {
 }
 
 # reindexing on removals
+EventBus.subscribe :message_changed, ->(message) {
+  Searchable::ReindexMessageThreadJob.perform_later(message.thread.id)
+}
+
 EventBus.subscribe :tag_renamed, ->(tag) do
   ReindexAndNotifyFilterSubscriptionsJob.perform_later_for_tag_id(tag.id)
 end

--- a/app/lib/event_bus.rb
+++ b/app/lib/event_bus.rb
@@ -37,7 +37,7 @@ EventBus.subscribe :message_thread_changed, ->(thread) {
 }
 
 # reindexing
-EventBus.subscribe :message_changed, ->(message) { Searchable::ReindexMessageThreadJob.perform_later(message.thread.id) }
+EventBus.subscribe :message_draft_changed, ->(message_draft) { Searchable::ReindexMessageThreadJob.perform_later(message_draft.thread.id) }
 
 # reindexing on removals
 EventBus.subscribe :tag_renamed, ->(tag) do

--- a/app/lib/event_bus.rb
+++ b/app/lib/event_bus.rb
@@ -36,11 +36,12 @@ EventBus.subscribe :message_thread_changed, ->(thread) {
   ReindexAndNotifyFilterSubscriptionsJob.perform_later(thread.id)
 }
 
-# reindexing on removals
-EventBus.subscribe :message_changed, ->(message) {
+# reindexing
+EventBus.subscribe :message_changed, ->(message) do
   Searchable::ReindexMessageThreadJob.perform_later(message.thread.id)
-}
+end
 
+# reindexing on removals
 EventBus.subscribe :tag_renamed, ->(tag) do
   ReindexAndNotifyFilterSubscriptionsJob.perform_later_for_tag_id(tag.id)
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -39,6 +39,7 @@ class Message < ApplicationRecord
   scope :outbox, -> { where(outbox: true) }
   scope :inbox, -> { where.not(outbox: true).where(type: nil).or(self.where.not(type: "MessageDraft")) }
 
+  after_update_commit ->(message) { EventBus.publish(:message_changed, message) }
   after_destroy_commit ->(message) { EventBus.publish(:message_destroyed, message) }
 
   def automation_rules_for_event(event)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -39,7 +39,6 @@ class Message < ApplicationRecord
   scope :outbox, -> { where(outbox: true) }
   scope :inbox, -> { where.not(outbox: true).where(type: nil).or(self.where.not(type: "MessageDraft")) }
 
-  after_update_commit ->(message) { EventBus.publish(:message_changed, message) }
   after_destroy_commit ->(message) { EventBus.publish(:message_destroyed, message) }
 
   def automation_rules_for_event(event)

--- a/app/models/message_draft.rb
+++ b/app/models/message_draft.rb
@@ -31,6 +31,7 @@ class MessageDraft < Message
   after_create do
     add_cascading_tag(thread.box.tenant.draft_tag!)
   end
+  after_update_commit ->(message) { EventBus.publish(:message_draft_changed, message) }
 
   after_destroy do
     EventBus.publish(:message_draft_destroyed, self)

--- a/test/lib/event_bus_test.rb
+++ b/test/lib/event_bus_test.rb
@@ -5,8 +5,8 @@ require "test_helper"
 class EventBusTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
-  test ":message_changed event schedules Searchable::ReindexMessageThreadJob" do
-    message = messages(:ssd_main_general_one)
+  test ":message_draft_changed event schedules Searchable::ReindexMessageThreadJob" do
+    message = messages(:ssd_main_general_draft_one)
 
     assert_enqueued_with(job: Searchable::ReindexMessageThreadJob) do
       message.update(html_visualization: '<html><head>some junk</head><body id="test">text</body>')

--- a/test/lib/event_bus_test.rb
+++ b/test/lib/event_bus_test.rb
@@ -3,6 +3,16 @@
 require "test_helper"
 
 class EventBusTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test ":message_changed event schedules Searchable::ReindexMessageThreadJob" do
+    message = messages(:ssd_main_general_one)
+
+    assert_enqueued_with(job: Searchable::ReindexMessageThreadJob) do
+      message.update(html_visualization: '<html><head>some junk</head><body id="test">text</body>')
+    end
+  end
+
   test "should fire matching subscribers" do
     subscriber1 = Minitest::Mock.new
     subscriber1.expect :call, true, [1, 2, 3]


### PR DESCRIPTION
Zistila som, ze v importovanych draftoch nie je mozne vyhladavat na zaklade ich obsahu, kedze sa atributy spravy updatuju postupne, ako sa draft spracovava a `EventBus` neodobera event `:message_changed`. Takze ked [neskor v postupe spracovania](https://github.com/slovensko-digital/govbox-pro/blob/GO-66/subscribe_for_message_changed_event/app/jobs/drafts/load_content_job.rb#L22) nastavime sprave html vizualizaciu, tak nezbehne reindex.
Navrhla som upravu, aby `EventBus` tento event odoberal.