### PR TITLE
GO-66 Automatically set Message.html_visualization after form data create

### DIFF
--- a/app/components/message_draft_body_component.html.erb
+++ b/app/components/message_draft_body_component.html.erb
@@ -43,9 +43,9 @@
   <div class="flex flex-col justify-stretch items-start relative gap-4 p-6 border-t-0 border-r-0 border-b border-l-0 border-gray-200">
     <% if @message.custom_visualization? %>
       <%= render MessageTemplateComponent.new(message: @message, is_last: @is_last) %>
-    <% elsif @message.build_visualization.present? %>
+    <% elsif @message.html_visualization.present? %>
       <div class="w-full">
-        <%= tag.iframe class: "relative border-none overflow-hidden h-full w-full", srcdoc: @message.build_visualization, onload: "(
+        <%= tag.iframe class: "relative border-none overflow-hidden h-full w-full", srcdoc: @message.html_visualization, onload: "(
             function(iframe) {
               iframe.contentWindow.document.body.style['height'] = 'unset';
               iframe.contentWindow.document.body.style['min-height'] = 'unset';

--- a/app/components/message_draft_body_component.html.erb
+++ b/app/components/message_draft_body_component.html.erb
@@ -43,9 +43,9 @@
   <div class="flex flex-col justify-stretch items-start relative gap-4 p-6 border-t-0 border-r-0 border-b border-l-0 border-gray-200">
     <% if @message.custom_visualization? %>
       <%= render MessageTemplateComponent.new(message: @message, is_last: @is_last) %>
-    <% elsif @message.visualization.present? %>
+    <% elsif @message.build_visualization.present? %>
       <div class="w-full">
-        <%= tag.iframe class: "relative border-none overflow-hidden h-full w-full", srcdoc: @message.visualization, onload: "(
+        <%= tag.iframe class: "relative border-none overflow-hidden h-full w-full", srcdoc: @message.build_visualization, onload: "(
             function(iframe) {
               iframe.contentWindow.document.body.style['height'] = 'unset';
               iframe.contentWindow.document.body.style['min-height'] = 'unset';

--- a/app/jobs/drafts/load_content_job.rb
+++ b/app/jobs/drafts/load_content_job.rb
@@ -60,18 +60,10 @@ class Drafts::LoadContentJob < ApplicationJob
   end
   
   def save_form_visualisation(message_draft)
-      message_draft.update(
-        html_visualization: message_draft.visualization
-      )
-
       if message_draft.custom_visualization?
         message_draft.metadata["message_body"] = Upvs::FormBuilder.parse_general_agenda_text(message_draft.form.content)
         message_draft.save!
       end
-
-      message_draft.form.update(
-        visualizable: true
-      ) if message_draft.html_visualization
   end
 
   delegate :uuid, to: self

--- a/app/lib/event_bus.rb
+++ b/app/lib/event_bus.rb
@@ -64,6 +64,7 @@ EventBus.subscribe :message_draft_destroyed, ->(message) { AuditLog::MessageDraf
 EventBus.subscribe :message_thread_renamed, ->(message_thread) { AuditLog::MessageThreadRenamed.create_audit_record(message_thread) }
 EventBus.subscribe :message_threads_merged, ->(message_threads_collection) { AuditLog::MessageThreadsMerged.create_audit_record(message_threads_collection) }
 EventBus.subscribe :message_object_updated, ->(message_object) { AuditLog::MessageObjectUpdated.create_audit_record(message_object) }
+EventBus.subscribe :message_form_data_created, ->(message) { message.set_html_visualization }
 
 EventBus.subscribe :user_logged_in, ->(user) { AuditLog::UserLoggedIn.create_audit_record(user) }
 EventBus.subscribe :user_logged_out, ->(user) { AuditLog::UserLoggedOut.create_audit_record(user) }

--- a/app/lib/event_bus.rb
+++ b/app/lib/event_bus.rb
@@ -64,7 +64,6 @@ EventBus.subscribe :message_draft_destroyed, ->(message) { AuditLog::MessageDraf
 EventBus.subscribe :message_thread_renamed, ->(message_thread) { AuditLog::MessageThreadRenamed.create_audit_record(message_thread) }
 EventBus.subscribe :message_threads_merged, ->(message_threads_collection) { AuditLog::MessageThreadsMerged.create_audit_record(message_threads_collection) }
 EventBus.subscribe :message_object_updated, ->(message_object) { AuditLog::MessageObjectUpdated.create_audit_record(message_object) }
-EventBus.subscribe :message_form_data_created, ->(message) { message.set_html_visualization }
 
 EventBus.subscribe :user_logged_in, ->(user) { AuditLog::UserLoggedIn.create_audit_record(user) }
 EventBus.subscribe :user_logged_out, ->(user) { AuditLog::UserLoggedOut.create_audit_record(user) }

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -99,7 +99,7 @@ class Message < ApplicationRecord
 
   def update_html_visualization
     self.update(
-      html_visualization: build_visualization
+      html_visualization: build_html_visualization
     )
 
     form.update(
@@ -107,7 +107,7 @@ class Message < ApplicationRecord
     )
   end
 
-  def build_visualization
+  def build_html_visualization
     return self.html_visualization if self.html_visualization.present?
 
     return unless upvs_form&.xslt_html

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -97,7 +97,7 @@ class Message < ApplicationRecord
     )
   end
 
-  def set_html_visualization
+  def update_html_visualization
     self.update(
       html_visualization: visualization
     )

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -97,6 +97,16 @@ class Message < ApplicationRecord
     )
   end
 
+  def set_html_visualization
+    self.update(
+      html_visualization: visualization
+    )
+
+    form.update(
+      visualizable: html_visualization.present?
+    )
+  end
+
   def visualization
     return self.html_visualization if self.html_visualization.present?
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -99,7 +99,7 @@ class Message < ApplicationRecord
 
   def update_html_visualization
     self.update(
-      html_visualization: visualization
+      html_visualization: build_visualization
     )
 
     form.update(
@@ -107,7 +107,7 @@ class Message < ApplicationRecord
     )
   end
 
-  def visualization
+  def build_visualization
     return self.html_visualization if self.html_visualization.present?
 
     return unless upvs_form&.xslt_html

--- a/app/models/message_object_datum.rb
+++ b/app/models/message_object_datum.rb
@@ -11,6 +11,6 @@
 class MessageObjectDatum < ApplicationRecord
   belongs_to :message_object
 
-  after_create_commit { message_object.message.set_html_visualization if message_object.form? }
+  after_create_commit { message_object.message.update_html_visualization if message_object.form? }
   after_save_commit { NestedMessageObject.create_from_message_object(message_object) }
 end

--- a/app/models/message_object_datum.rb
+++ b/app/models/message_object_datum.rb
@@ -11,6 +11,6 @@
 class MessageObjectDatum < ApplicationRecord
   belongs_to :message_object
 
-  after_create_commit { EventBus.publish(:message_form_data_created, message_object.message) if message_object.form? }
+  after_create_commit { message_object.message.set_html_visualization if message_object.form? }
   after_save_commit { NestedMessageObject.create_from_message_object(message_object) }
 end

--- a/app/models/message_object_datum.rb
+++ b/app/models/message_object_datum.rb
@@ -11,5 +11,6 @@
 class MessageObjectDatum < ApplicationRecord
   belongs_to :message_object
 
+  after_create_commit { EventBus.publish(:message_form_data_created, message_object.message) if message_object.form? }
   after_save_commit { NestedMessageObject.create_from_message_object(message_object) }
 end

--- a/db/migrate/20240501213603_update_messages_html_visualization.rb
+++ b/db/migrate/20240501213603_update_messages_html_visualization.rb
@@ -1,0 +1,9 @@
+class UpdateMessagesHtmlVisualization < ActiveRecord::Migration[7.1]
+  def change
+    Message.find_each do |message|
+      next unless message.html_visualization.present?
+
+      message.update_html_visualization
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_08_100351) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_01_213603) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -39,6 +39,17 @@ ssd_main_general_three:
   metadata: {}
   collapsed: true
 
+ssd_main_general_four:
+  uuid: <%= SecureRandom.uuid %>
+  title: The Fourth Message
+  delivered_at: 2023-05-18 16:17:26
+  thread: ssd_main_general
+  metadata:
+    authorized: false
+    posp_id: App.GeneralAgenda
+    posp_version: 1.9
+    message_type: App.GeneralAgenda
+
 ssd_main_general_draft_one:
   type: MessageDraft
   uuid: <%= SecureRandom.uuid %>

--- a/test/fixtures/upvs/form_related_documents.yml
+++ b/test/fixtures/upvs/form_related_documents.yml
@@ -5,3 +5,158 @@ general_agenda_xsd:
   document_type: CLS_F_XSD_EDOC
   language: sk
   form: general_agenda
+
+general_agenda_html_xslt:
+  data: <?xml version="1.0" encoding="UTF-8"?>
+    <xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:egonp="http://schemas.gov.sk/form/App.GeneralAgenda/1.9" exclude-result-prefixes="egonp">
+    <xsl:output method="html" doctype-system="http://www.w3.org/TR/html4/strict.dtd" doctype-public="-//W3C//DTD HTML 4.01//EN" indent="no" omit-xml-declaration="yes"/>
+    <xsl:template match="/">
+    <html>
+    <head>
+      <meta http-equiv="X-UA-Compatible" content="IE=8" />
+      <title>Všeobecná agenda</title>
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+      <meta name="language" content="sk-SK"/>
+    </head>
+    <body>
+    <div id="main" class="layoutMain">
+    <xsl:apply-templates/>
+    </div>
+    </body>
+    </html>
+    </xsl:template>
+    <xsl:template match="/egonp:GeneralAgenda">
+    <div class="layoutRow ui-tabs ui-widget-content" >
+    <div class="caption ui-widget-header">
+    <div class="headercorrection">Všeobecná agenda</div>
+    </div>
+    <xsl:apply-templates select="./egonp:subject"/>
+    <xsl:apply-templates select="./egonp:text"/>
+    </div>
+    </xsl:template>
+    <xsl:template match="egonp:GeneralAgenda/egonp:subject">
+    <xsl:if test="./text()">
+    <div>
+    <label class="labelVis">Predmet:</label>
+    <span class="contentVis wordwrap">
+    <xsl:call-template name="string-replace-all">
+    <xsl:with-param name="text" select="." />
+    <xsl:with-param name="replace" select="'%0A'" />
+    <xsl:with-param name="by" select="'&#13;&#10;'" />
+    </xsl:call-template>
+    </span>
+    </div>
+    <div class="clear">&#xa0;</div>
+    </xsl:if>
+    </xsl:template>
+    <xsl:template match="egonp:GeneralAgenda/egonp:text">
+    <xsl:if test="./text()">
+    <div>
+    <label class="labelVis">Text:</label>
+    <span class="contentVis wordwrap">
+    <xsl:call-template name="string-replace-all">
+    <xsl:with-param name="text" select="." />
+    <xsl:with-param name="replace" select="'%0A'" />
+    <xsl:with-param name="by" select="'&#13;&#10;'" />
+    </xsl:call-template>
+    </span>
+    </div>
+    <div class="clear">&#xa0;</div>
+    </xsl:if>
+    </xsl:template>
+    <xsl:template name="formatToSkDate">
+    <xsl:param name="date" />
+    <xsl:variable name="dateString" select="string($date)" />
+    <xsl:choose>
+    <xsl:when test="$dateString != '' and string-length($dateString)=10 and string(number(substring($dateString, 1, 4))) != 'NaN' ">
+    <xsl:value-of select="concat(substring($dateString, 9, 2), '.', substring($dateString, 6, 2), '.', substring($dateString, 1, 4))" />
+    </xsl:when>
+    <xsl:otherwise>
+    <xsl:value-of select="$dateString"></xsl:value-of>
+    </xsl:otherwise>
+    </xsl:choose>
+    </xsl:template>
+    <xsl:template name="booleanCheckboxToString">
+    <xsl:param name="boolValue" />
+    <xsl:variable name="boolValueString" select="string($boolValue)" />
+    <xsl:choose>
+    <xsl:when test="$boolValueString = 'true' ">
+    <xsl:text>Áno</xsl:text>
+    </xsl:when>
+    <xsl:when test="$boolValueString = 'false' ">
+    <xsl:text>Nie</xsl:text>
+    </xsl:when>
+    <xsl:when test="$boolValueString = '1' ">
+    <xsl:text>Áno</xsl:text>
+    </xsl:when>
+    <xsl:when test="$boolValueString = '0' ">
+    <xsl:text>Nie</xsl:text>
+    </xsl:when>
+    <xsl:otherwise>
+    <xsl:value-of select="$boolValueString"></xsl:value-of>
+    </xsl:otherwise>
+    </xsl:choose>
+    </xsl:template>
+    <xsl:template name="formatTimeTrimSeconds">
+    <xsl:param name="time" />
+    <xsl:variable name="timeString" select="string($time)" />
+    <xsl:if test="$timeString != ''">
+    <xsl:value-of select="substring($timeString, 1, 5)" />
+    </xsl:if>
+    </xsl:template>
+    <xsl:template name="formatTime">
+    <xsl:param name="time" />
+    <xsl:variable name="timeString" select="string($time)" />
+    <xsl:if test="$timeString != ''">
+    <xsl:value-of select="substring($timeString, 1, 8)" />
+    </xsl:if>
+    </xsl:template>
+    <xsl:template name="string-replace-all">
+    <xsl:param name="text"/>
+    <xsl:param name="replace"/>
+    <xsl:param name="by"/>
+    <xsl:choose>
+    <xsl:when test="contains($text, $replace)">
+    <xsl:value-of select="substring-before($text,$replace)"/>
+    <xsl:value-of select="$by"/>
+    <xsl:call-template name="string-replace-all">
+    <xsl:with-param name="text" select="substring-after($text,$replace)"/>
+    <xsl:with-param name="replace" select="$replace"/>
+    <xsl:with-param name="by" select="$by" />
+    </xsl:call-template>
+    </xsl:when>
+    <xsl:otherwise>
+    <xsl:value-of select="$text"/>
+    </xsl:otherwise>
+    </xsl:choose>
+    </xsl:template>
+    <xsl:template name="formatToSkDateTime">
+    <xsl:param name="dateTime" />
+    <xsl:variable name="dateTimeString" select="string($dateTime)" />
+    <xsl:choose>
+    <xsl:when test="$dateTimeString!= '' and string-length($dateTimeString)>18 and string(number(substring($dateTimeString, 1, 4))) != 'NaN' ">
+    <xsl:value-of select="concat(substring($dateTimeString, 9, 2), '.', substring($dateTimeString, 6, 2), '.', substring($dateTimeString, 1, 4),' ', substring($dateTimeString, 12, 2),':', substring($dateTimeString, 15, 2))" />
+    </xsl:when>
+    <xsl:otherwise>
+    <xsl:value-of select="$dateTimeString"></xsl:value-of>
+    </xsl:otherwise>
+    </xsl:choose>
+    </xsl:template>
+    <xsl:template name="formatToSkDateTimeSecond">
+    <xsl:param name="dateTime" />
+    <xsl:variable name="dateTimeString" select="string($dateTime)" />
+    <xsl:choose>
+    <xsl:when test="$dateTimeString!= '' and string-length($dateTimeString)>18 and string(number(substring($dateTimeString, 1, 4))) != 'NaN' ">
+    <xsl:value-of select="concat(substring($dateTimeString, 9, 2), '.', substring($dateTimeString, 6, 2), '.', substring($dateTimeString, 1, 4),' ', substring($dateTimeString, 12, 2),':', substring($dateTimeString, 15, 2),':', substring($dateTimeString, 18, 2))" />
+    </xsl:when>
+    <xsl:otherwise>
+    <xsl:value-of select="$dateTimeString"></xsl:value-of>
+    </xsl:otherwise>
+    </xsl:choose>
+    </xsl:template>
+    </xsl:stylesheet>
+  document_type: CLS_F_XSLT_HTML
+  language: sk
+  form: general_agenda

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,6 +1,22 @@
 require "test_helper"
 
 class MessageTest < ActiveSupport::TestCase
+  test "Automatically sets html_visualization after form object data created" do
+    message = messages(:ssd_main_general_four)
+
+    form = message.objects.create(
+      name: 'form',
+      mimetype: 'application/xml',
+      object_type: 'FORM'
+    )
+    MessageObjectDatum.create(
+      message_object: form,
+      blob: '<GeneralAgenda xmlns="http://schemas.gov.sk/form/App.GeneralAgenda/1.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><subject>predmet</subject><text>text</text></GeneralAgenda>'
+    )
+
+    assert message.html_visualization.present?
+  end
+
   test "add_cascade_tag method should add tag to message and message thread" do
     message = messages(:ssd_main_general_one)
     tag = tags(:ssd_finance)


### PR DESCRIPTION
Po nacitani obsahu formulara potrebujeme pri draftoch ulozit HTML vizualizaciu. Pri importovanych draftoch sme to doteraz priamo vynucovali po nacitani vsetkych message objektov, ale pri API mi to pride ako tahanie logiky do controllera, kedze by sme to potrebovali dat niekde sem: https://github.com/slovensko-digital/govbox-pro/blob/main/app/controllers/api/messages_controller.rb#L34, tak som to vytiahla do `EventBus`.
Doteraz sme to pri draftoch z API neriesili a teda ich obsah nie je indexovany, kedze `html_visualization` je `nil`.

Bolo by fajn spravit aj nejaky update existujucich draftov.