### PR TITLE
Make FOP use Saxon parser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM ruby:3.3.0
 
 # Install packages
-RUN apt-get update && apt-get install -y build-essential nodejs libpq-dev npm fop
+RUN apt-get update && apt-get install -y build-essential nodejs libpq-dev npm fop=1:2.* libsaxon-java libsaxonb-java
+
+# Setup FOP to use saxon xslt parser
+RUN sed -i '/find_jars/i \
+find_jars saxon saxonb' /usr/bin/fop
+RUN sed -i 's/^run_java /run_java -Djavax.xml.transform.TransformerFactory=net.sf.saxon.TransformerFactoryImpl /' /usr/bin/fop
 
 # Set working directory
 RUN mkdir /app


### PR DESCRIPTION
Už funkčné PDF, ktoré predtým nešlo:

<img width="987" alt="Snímka obrazovky 2024-05-13 o 10 53 07" src="https://github.com/slovensko-digital/govbox-pro/assets/12500066/21e12daa-6aa5-4bfb-849f-11284ca2affd">


Testy na GH zatiaľ asi nevedia spúšťať fop command (ten sa inštaluje v Dockerfile, ktorý sa v GH pipeline nepoužíva)