### PR TITLE
GO-92 Allow export on message drafts

### DIFF
--- a/app/policies/message_draft_policy.rb
+++ b/app/policies/message_draft_policy.rb
@@ -46,6 +46,10 @@ class MessageDraftPolicy < ApplicationPolicy
     create?
   end
 
+  def export?
+    show?
+  end
+
   def submit?
     create?
   end

--- a/app/policies/upvs/message_draft_policy.rb
+++ b/app/policies/upvs/message_draft_policy.rb
@@ -46,6 +46,10 @@ class ::Upvs::MessageDraftPolicy < ApplicationPolicy
     create?
   end
 
+  def export?
+    show?
+  end
+
   def submit?
     create?
   end


### PR DESCRIPTION
Aktualne sa tlacidlo exportu zobrazuje aj pri draftoch, ale chyba policy, takze export zlyha. Sice export pri draftoch neviem ci je potrebny, ale nevidim ani dovod ho zakazovat.