### PR TITLE
Update signing_data in MessageObjectsController

### DIFF
--- a/app/controllers/message_objects_controller.rb
+++ b/app/controllers/message_objects_controller.rb
@@ -49,7 +49,7 @@ class MessageObjectsController < ApplicationController
     authorize @message_object
 
     head :no_content and return unless @message_object.content.present?
-    render template: 'message_drafts/update_body' and return unless @message.valid?(:validate_data)
+    render template: 'message_drafts/update_body' and return if @message_object.form? && !@message.valid?(:validate_data)
   end
 
   def destroy


### PR DESCRIPTION
Aktualne nie je mozne podpisovat prilohy, ak napr. este nie je vyplneny formular sablonoveho draftu. Preto navrhjem, ze validovat obsah spravy by sa mal iba pri podpisovani formular objektu, pri zvysku to je jedno.