### PR TITLE
GO-110 Fix generating FS boxes short name

### DIFF
--- a/app/models/fs/api_connection.rb
+++ b/app/models/fs/api_connection.rb
@@ -72,9 +72,14 @@ class Fs::ApiConnection < ::ApiConnection
   private
 
   def generate_short_name_from_name(name)
-    generated_short_name = "FS" + name.split.map(&:first).join.upcase
-    boxes_with_same_short_name_count = tenant.boxes.where("short_name ~ ?", "#{generated_short_name}(%d)*").count
-    generated_short_name += boxes_with_same_short_name_count.to_s if boxes_with_same_short_name_count > 0
+    generated_base_short_name = "FS" + name.split.map(&:first).join.upcase
+    generated_short_name = generated_base_short_name
+
+    1.step do |i|
+      break if tenant.boxes.where("short_name ~ ?", "#{generated_short_name}(%d)*").empty?
+
+      generated_short_name = generated_base_short_name + i.to_s
+    end
 
     generated_short_name
   end

--- a/app/models/fs/api_connection.rb
+++ b/app/models/fs/api_connection.rb
@@ -73,7 +73,8 @@ class Fs::ApiConnection < ::ApiConnection
 
   def generate_short_name_from_name(name)
     generated_short_name = "FS" + name.split.map(&:first).join.upcase
-    generated_short_name += tenant.boxes.where(short_name: generated_short_name).count.to_s if tenant.boxes.where(short_name: generated_short_name).any?
+    boxes_with_same_short_name_count = tenant.boxes.where("short_name ~ ?", "#{generated_short_name}(%d)*").count
+    generated_short_name += boxes_with_same_short_name_count.to_s if boxes_with_same_short_name_count > 0
 
     generated_short_name
   end

--- a/app/models/fs/api_connection.rb
+++ b/app/models/fs/api_connection.rb
@@ -72,14 +72,14 @@ class Fs::ApiConnection < ::ApiConnection
   private
 
   def generate_short_name_from_name(name)
-    generated_base_short_name = "FS" + name.split.map(&:first).join.upcase
-    generated_short_name = generated_base_short_name
+    generated_short_name = "FS" + name.split.map(&:first).join.upcase
 
     1.step do |i|
-      break if tenant.boxes.where("short_name ~ ?", "#{generated_short_name}(%d)*").empty?
-
-      generated_short_name = generated_base_short_name + i.to_s
-    end
+      if tenant.boxes.where(short_name: "#{generated_short_name}#{i}").empty?
+        generated_short_name = "#{generated_short_name}#{i}"
+        break
+      end
+    end if tenant.boxes.where("short_name ~ ?", "#{generated_short_name}(%d)*").any?
 
     generated_short_name
   end

--- a/app/models/fs/api_connection.rb
+++ b/app/models/fs/api_connection.rb
@@ -58,7 +58,7 @@ class Fs::ApiConnection < ::ApiConnection
           api_connection: self,
           tenant: tenant,
           name: "FS " + subject["name"],
-          short_name: "FS" + subject["name"].split.map(&:first).join.upcase,
+          short_name: generate_short_name_from_name(subject["name"]),
           uri: "dic://sk/#{subject['dic']}",
           syncable: false
         )
@@ -67,5 +67,14 @@ class Fs::ApiConnection < ::ApiConnection
     end
 
     count
+  end
+
+  private
+
+  def generate_short_name_from_name(name)
+    generated_short_name = "FS" + name.split.map(&:first).join.upcase
+    generated_short_name += tenant.boxes.where(short_name: generated_short_name).count.to_s if tenant.boxes.where(short_name: generated_short_name).any?
+
+    generated_short_name
   end
 end

--- a/app/models/fs/api_connection.rb
+++ b/app/models/fs/api_connection.rb
@@ -72,15 +72,14 @@ class Fs::ApiConnection < ::ApiConnection
   private
 
   def generate_short_name_from_name(name)
-    generated_short_name = "FS" + name.split.map(&:first).join.upcase
+    generated_base_name = "FS" + name.split.map(&:first).join.upcase
+
+    return generated_base_name unless tenant.boxes.where(short_name: generated_base_name).present?
 
     1.step do |i|
-      if tenant.boxes.where(short_name: "#{generated_short_name}#{i}").empty?
-        generated_short_name = "#{generated_short_name}#{i}"
-        break
-      end
-    end if tenant.boxes.where("short_name ~ ?", "#{generated_short_name}(%d)*").any?
+      generated_short_name = "#{generated_base_name}#{i}"
 
-    generated_short_name
+      return generated_short_name unless tenant.boxes.where(short_name: generated_short_name).present?
+    end
   end
 end

--- a/test/fixtures/api_connections.yml
+++ b/test/fixtures/api_connections.yml
@@ -50,6 +50,7 @@ fs_api_connection1:
   sub: fs_sub1
   api_token_private_key: private_key
   type: 'Fs::ApiConnection'
+  tenant: accountants
   settings: {"username": "1234567", "password": "fs_password"}
 
 sk_api_api_connection_with_obo_support:

--- a/test/fixtures/boxes.yml
+++ b/test/fixtures/boxes.yml
@@ -53,7 +53,7 @@ fs_accountants:
   name: Accountants main FS
   uri: dic://sk/1122334455
   tenant: accountants
-  short_name: MY2
+  short_name: FSJJ
   api_connection: fs_api_connection1
   settings: {"dic": "1122334455"}
   type: 'Fs::Box'

--- a/test/fixtures/boxes.yml
+++ b/test/fixtures/boxes.yml
@@ -57,3 +57,12 @@ fs_accountants:
   api_connection: fs_api_connection1
   settings: {"dic": "1122334455"}
   type: 'Fs::Box'
+
+fs_accountants2:
+  name: Accountants main FS
+  uri: dic://sk/1122334456
+  tenant: accountants
+  short_name: FSJJ3
+  api_connection: fs_api_connection1
+  settings: {"dic": "1122334456"}
+  type: 'Fs::Box'

--- a/test/models/fs/api_connection_test.rb
+++ b/test/models/fs/api_connection_test.rb
@@ -8,6 +8,21 @@ class Fs::ApiConnectionTest < ActiveSupport::TestCase
 
   test ".generate_short_name_from_name generates short name with number if not unique" do
     api_connection = api_connections(:fs_api_connection1)
-    assert_equal 'FSJJ1', api_connection.send(:generate_short_name_from_name, 'Juraj Jánošík')
+    box = boxes(:fs_accountants)
+
+    [
+      'Juraj Jánošík',
+      'Ján Jánošík',
+      'Ján Jabĺčko',
+      'Juraj Jabĺčko'
+    ].each_with_index do |new_box_name, i|
+      new_box = box.dup
+      new_box.name = new_box_name
+      new_box.uri = SecureRandom.hex
+      new_box.short_name = api_connection.send(:generate_short_name_from_name, new_box_name)
+      new_box.save
+
+      assert_equal "FSJJ#{i + 1}", new_box.short_name
+    end
   end
 end

--- a/test/models/fs/api_connection_test.rb
+++ b/test/models/fs/api_connection_test.rb
@@ -10,19 +10,40 @@ class Fs::ApiConnectionTest < ActiveSupport::TestCase
     api_connection = api_connections(:fs_api_connection1)
     box = boxes(:fs_accountants)
 
-    [
-      'Juraj Jánošík',
-      'Ján Jánošík',
-      'Ján Jabĺčko',
-      'Juraj Jabĺčko'
-    ].each_with_index do |new_box_name, i|
-      new_box = box.dup
-      new_box.name = new_box_name
-      new_box.uri = SecureRandom.hex
-      new_box.short_name = api_connection.send(:generate_short_name_from_name, new_box_name)
-      new_box.save
+    new_box = box.dup
+    new_box.name = 'Juraj Jánošík'
+    new_box.uri = SecureRandom.hex
+    new_box.short_name = api_connection.send(:generate_short_name_from_name, 'Juraj Jánošík')
+    new_box.save
 
-      assert_equal "FSJJ#{i + 1}", new_box.short_name
-    end
+    assert_equal "FSJJ1", new_box.short_name
+
+
+    new_box = box.dup
+    new_box.name = 'Ján Jánošík'
+    new_box.uri = SecureRandom.hex
+    new_box.short_name = api_connection.send(:generate_short_name_from_name, 'Ján Jánošík')
+    new_box.save
+
+    assert_equal "FSJJ2", new_box.short_name
+
+
+    # skips number 3 which is already used
+    new_box = box.dup
+    new_box.name = 'Ján Jabĺčko'
+    new_box.uri = SecureRandom.hex
+    new_box.short_name = api_connection.send(:generate_short_name_from_name, 'Ján Jabĺčko')
+    new_box.save
+
+    assert_equal "FSJJ4", new_box.short_name
+
+
+    new_box = box.dup
+    new_box.name = 'Juraj Jabĺčko'
+    new_box.uri = SecureRandom.hex
+    new_box.short_name = api_connection.send(:generate_short_name_from_name, 'Juraj Jabĺčko')
+    new_box.save
+
+    assert_equal "FSJJ5", new_box.short_name
   end
 end

--- a/test/models/fs/api_connection_test.rb
+++ b/test/models/fs/api_connection_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Fs::ApiConnectionTest < ActiveSupport::TestCase
+  test ".generate_short_name_from_name generates short name without number if unique" do
+    api_connection = api_connections(:fs_api_connection1)
+    assert_equal 'FSJH', api_connection.send(:generate_short_name_from_name, 'Janko Hraško')
+  end
+
+  test ".generate_short_name_from_name generates short name with number if not unique" do
+    api_connection = api_connections(:fs_api_connection1)
+    assert_equal 'FSJJ1', api_connection.send(:generate_short_name_from_name, 'Juraj Jánošík')
+  end
+end


### PR DESCRIPTION
Problem doteraz bol taky, ze ak sa mali nacitat z FS dva boxy, ktore mali rovnake inicialy, tak bola validacia na `short_name` neuspesna a vytvoril sa iba jeden box s danymi inicialmi.
Natrafili sme na to pri testovani s potenc. klientom.