### PR TITLE
GO-110 Add message_drafts_import_enabled attribute to box settings

### DIFF
--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -35,7 +35,6 @@ class Box < ApplicationRecord
   before_create { self.color = Box.colors.keys[name.hash % Box.colors.size] if color.blank? }
 
   validates_presence_of :name, :short_name, :uri
-  validates_uniqueness_of :name, :short_name, :uri, scope: :tenant_id
   validate :validate_box_with_api_connection
 
   store_accessor :settings, :obo, prefix: true # TODO: move to Govbox::Box superclass?

--- a/app/models/fs/api_connection.rb
+++ b/app/models/fs/api_connection.rb
@@ -56,12 +56,13 @@ class Fs::ApiConnection < ::ApiConnection
         api_connection: self,
         settings: {
           dic: subject["dic"],
-          subject_id: subject["subject_id"]
+          subject_id: subject["subject_id"],
+          message_drafts_import_enabled: Fs::Box::DISABLED_MESSAGE_DRAFTS_IMPORT_KEYWORDS.none? { |keyword| subject["name"].include?(keyword) }
         }
       ).tap do |box|
         box.name = "FS " + subject["name"]
         box.short_name ||= generate_short_name_from_name(subject["name"])
-        box.uri = "dic://sk/#{subject['dic']}"
+        box.uri = "dic://sk/#{subject['dic']}_#{subject["name"]}"
         box.syncable = false
       end
 

--- a/app/models/fs/api_connection.rb
+++ b/app/models/fs/api_connection.rb
@@ -62,7 +62,7 @@ class Fs::ApiConnection < ::ApiConnection
       ).tap do |box|
         box.name = "FS " + subject["name"]
         box.short_name ||= generate_short_name_from_name(subject["name"])
-        box.uri = "dic://sk/#{subject['dic']}_#{subject["name"]}"
+        box.uri = "dic://sk/#{subject['dic']}"
         box.syncable = false
       end
 

--- a/app/models/fs/box.rb
+++ b/app/models/fs/box.rb
@@ -16,6 +16,10 @@
 #  tenant_id         :bigint           not null
 #
 class Fs::Box < Box
+  DISABLED_MESSAGE_DRAFTS_IMPORT_KEYWORDS = ['(oblasť SPD)']
+
+  scope :with_enabled_message_drafts_import, -> { where("(settings ->> 'message_drafts_import_enabled')::boolean = ?", true) }
+
   def self.policy_class
     BoxPolicy
   end

--- a/app/models/fs/box.rb
+++ b/app/models/fs/box.rb
@@ -20,6 +20,8 @@ class Fs::Box < Box
 
   scope :with_enabled_message_drafts_import, -> { where("(settings ->> 'message_drafts_import_enabled')::boolean = ?", true) }
 
+  validates_uniqueness_of :name, :short_name, scope: :tenant_id
+
   def self.policy_class
     BoxPolicy
   end

--- a/app/models/fs/message_draft.rb
+++ b/app/models/fs/message_draft.rb
@@ -35,7 +35,7 @@ class Fs::MessageDraft < MessageDraft
       dic = form_information['subject']
       fs_form_identifier = form_information['form_identifier']
 
-      box = Fs::Box.find_by("settings ->> 'dic' = ?", dic)
+      box = Fs::Box.with_enabled_message_drafts_import.find_by("settings ->> 'dic' = ?", dic)
       fs_form = Fs::Form.find_by(identifier: fs_form_identifier)
 
       unless box && fs_form

--- a/app/models/upvs/box.rb
+++ b/app/models/upvs/box.rb
@@ -20,6 +20,8 @@ class Upvs::Box < Box
     BoxPolicy
   end
 
+  validates_uniqueness_of :name, :short_name, :uri, scope: :tenant_id
+
   store_accessor :settings, :obo, prefix: true
 
   def self.create_with_api_connection!(params)

--- a/db/migrate/20240716140732_update_fs_boxes_settings.rb
+++ b/db/migrate/20240716140732_update_fs_boxes_settings.rb
@@ -1,8 +1,7 @@
-class UpdateFsBoxesSettingsAndUri < ActiveRecord::Migration[7.1]
+class UpdateFsBoxesSettings < ActiveRecord::Migration[7.1]
   def up
     Fs::Box.find_each do |box|
       box.settings['message_drafts_import_enabled'] = Fs::Box::DISABLED_MESSAGE_DRAFTS_IMPORT_KEYWORDS.none? { |keyword| box.name.include?(keyword) }
-      box.uri = "dic://sk/#{box.settings_dic}_#{box.name}"
 
       box.save
     end

--- a/db/migrate/20240716140732_update_fs_boxes_settings_and_uri.rb
+++ b/db/migrate/20240716140732_update_fs_boxes_settings_and_uri.rb
@@ -1,0 +1,10 @@
+class UpdateFsBoxesSettingsAndUri < ActiveRecord::Migration[7.1]
+  def up
+    Fs::Box.find_each do |box|
+      box.settings['message_drafts_import_enabled'] = Fs::Box::DISABLED_MESSAGE_DRAFTS_IMPORT_KEYWORDS.none? { |keyword| box.name.include?(keyword) }
+      box.uri = "dic://sk/#{box.settings_dic}_#{box.name}"
+
+      box.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_13_095110) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_16_140732) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/test/fixtures/boxes.yml
+++ b/test/fixtures/boxes.yml
@@ -55,7 +55,7 @@ fs_accountants:
   tenant: accountants
   short_name: FSJJ
   api_connection: fs_api_connection1
-  settings: {"dic": "1122334455", "subject_id": "df2f9373-30b7-4a44-9738-5b4e24e4866c"}
+  settings: {"dic": "1122334455", "subject_id": "df2f9373-30b7-4a44-9738-5b4e24e4866c", "message_drafts_import_enabled": true}
   type: 'Fs::Box'
 
 fs_accountants2:
@@ -64,5 +64,5 @@ fs_accountants2:
   tenant: accountants
   short_name: FSJJ3
   api_connection: fs_api_connection1
-  settings: {"dic": "1122334456", "subject_id": "387cf7da-2cff-40e0-8ad2-650030429994"}
+  settings: {"dic": "1122334456", "subject_id": "387cf7da-2cff-40e0-8ad2-650030429994", "message_drafts_import_enabled": true}
   type: 'Fs::Box'

--- a/test/models/fs/api_connection_test.rb
+++ b/test/models/fs/api_connection_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class Fs::ApiConnectionTest < ActiveSupport::TestCase
-  test ".boxify saves only one box with given DIČ in the tenant" do
+  test ".boxify sets message_drafts_import_enabled attribute in settings" do
     original_fs_boxes_count = Fs::Box.count
 
     fs_api = Minitest::Mock.new
@@ -17,7 +17,10 @@ class Fs::ApiConnectionTest < ActiveSupport::TestCase
       api_connection.boxify
     end
 
-    assert_equal original_fs_boxes_count + 1, Fs::Box.count
+    assert_equal original_fs_boxes_count + 3, Fs::Box.count
+    assert_equal true, Fs::Box.find_by(name: 'FS SSD s.r.o.').settings['message_drafts_import_enabled']
+    assert_equal false, Fs::Box.find_by(name: 'FS SSD s.r.o. (oblasť SPD)').settings['message_drafts_import_enabled']
+    assert_equal true, Fs::Box.find_by(name: 'FS SSD s.r.o. (oblasť XYZ)').settings['message_drafts_import_enabled']
   end
 
   test ".boxify ignores duplicated boxes with different authorization type" do


### PR DESCRIPTION
Schranky, ktore su z oblasti SPD zatial oznacujeme, ze nie su urcene na podania, aby sme dosiahli to, ze vo zvysnych schrankach, tych, ktore su urcene na podania bude unikatne DIC.
Aktualne to nema ziaden dosah, nakolko SPD formulare ani FS API zatial rozparsovat nevie, takze take podania zatial odmietame. 