### PR TITLE
add message uuid to webhook payload

### DIFF
--- a/app/models/automation/webhook.rb
+++ b/app/models/automation/webhook.rb
@@ -21,6 +21,7 @@ module Automation
         type: "#{message.class.name.underscore}.#{event}",
         timestamp: timestamp,
         data: {
+          message_uuid: message.uuid,
           message_id: message.id,
           message_thread_id: message.thread.id
         }

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -903,6 +903,10 @@ components:
           type: object
           description: Dáta o objekte spúšťajúcom webhook
           properties:
+            message_uuid:
+              description: UUID správy
+              type: string
+              format: uuid
             message_id:
               type: integer
               description: Identifikátor správy

--- a/test/jobs/automation/fire_webhook_job_test.rb
+++ b/test/jobs/automation/fire_webhook_job_test.rb
@@ -9,6 +9,7 @@ class Automation::FireWebhookJobTest < ActiveJob::TestCase
       type: "#{message1.class.name.underscore}.#{event}",
       timestamp: timestamp,
       data: {
+        message_uuid: message1.uuid,
         message_id: message1.id,
         message_thread_id: message1.thread.id
       }

--- a/test/models/automation/webhook_test.rb
+++ b/test/models/automation/webhook_test.rb
@@ -9,6 +9,7 @@ class Automation::WebhookTest < ActiveSupport::TestCase
       type: "#{message1.class.name.underscore}.#{event}",
       timestamp: timestamp,
       data: {
+        message_uuid: message1.uuid,
         message_id: message1.id,
         message_thread_id: message1.thread.id
       }


### PR DESCRIPTION
`uuid` je not null atribút každej správy v GO. Cez API si ju nastavuje klient, takže pre neho dáva zmysel dostať z webhooku toto `uuid`.