### PR TITLE
Add unique index on uuid, message_thread_id to Messages

### DIFF
--- a/app/jobs/govbox/process_message_job.rb
+++ b/app/jobs/govbox/process_message_job.rb
@@ -10,9 +10,10 @@ module Govbox
       processed_message = ::Message.where(type: [nil, 'Message']).where(uuid: govbox_message.message_id).joins(:thread).where(thread: { box_id: govbox_message.box.id }).take
 
       ActiveRecord::Base.transaction do
+        destroy_associated_message_draft(govbox_message)
+
         message = Govbox::Message.create_message_with_thread!(govbox_message)
 
-        destroy_associated_message_draft(govbox_message)
         mark_delivery_notification_authorized(govbox_message)
         mark_associated_delivery_notification_authorized(govbox_message)
         collapse_referenced_outbox_message(message)

--- a/db/migrate/20240814102352_add_unique_index_on_uuid_message_thread_id_to_messages.rb
+++ b/db/migrate/20240814102352_add_unique_index_on_uuid_message_thread_id_to_messages.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexOnUuidMessageThreadIdToMessages < ActiveRecord::Migration[7.0]
+  def up
+    add_index :messages, [:uuid, :message_thread_id], unique: true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_18_084836) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_14_102352) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -486,6 +486,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_18_084836) do
     t.index ["author_id"], name: "index_messages_on_author_id"
     t.index ["import_id"], name: "index_messages_on_import_id"
     t.index ["message_thread_id"], name: "index_messages_on_message_thread_id"
+    t.index ["uuid", "message_thread_id"], name: "index_messages_on_uuid_and_message_thread_id", unique: true
   end
 
   create_table "messages_tags", force: :cascade do |t|

--- a/test/models/message_draft_test.rb
+++ b/test/models/message_draft_test.rb
@@ -57,7 +57,9 @@ class MessageDraftTest < ActiveSupport::TestCase
 
   test 'being_submitted! keeps DraftTag if drafts not in submission process present' do
     message_draft = messages(:ssd_main_delivery_draft)
+
     message_draft2 = message_draft.dup
+    message_draft2.update(uuid: SecureRandom.uuid)
     message_draft2.save
 
     message_draft.being_submitted!
@@ -109,6 +111,7 @@ class MessageDraftTest < ActiveSupport::TestCase
     message_draft.being_submitted!
 
     message_draft2 = message_draft.dup
+    message_draft2.update(uuid: SecureRandom.uuid)
     message_draft2.save
 
     message_thread = message_draft.thread


### PR DESCRIPTION
Ukazalo sa, ze niektore spravy v core domene mame duplicitne. Predpokladam, ze prislo k subeznemu spusteniu dvoch `Govbox::ProcessMessageJob`ov nad rovnakou spravou.
Pozerala som opatrne individualne pripady a precistila to radsej manualne. Bolo by vhodne podla mna pridat unique index na uuid v ramci threadu.