### PR TITLE
GO-127 Show sender name by FS MessageThreads

### DIFF
--- a/app/components/message_threads_table_row_component.html.erb
+++ b/app/components/message_threads_table_row_component.html.erb
@@ -27,9 +27,13 @@
         <div class="flex flex-wrap gap-2 text-gray-500 text-xs md:text-base items-center">
           <% if @message_thread.sender || @message_thread.recipient %>
             <span class="text-left font-normal">
-              <% if @message_thread.is_outbox && @message_thread.recipient.present? %>
-                Komu: <%= @message_thread.recipient %>
-              <% elsif !@message_thread.is_outbox && @message_thread.sender.present? %>
+              <% if @message_thread.box.communication_to_multiple_subjects? %>
+                <% if @message_thread.is_outbox && @message_thread.recipient.present? %>
+                  Komu: <%= @message_thread.recipient %>
+                <% elsif !@message_thread.is_outbox && @message_thread.sender.present? %>
+                  Od: <%= @message_thread.sender %>
+                <% end %>
+              <% elsif @message_thread.sender.present? %>
                 Od: <%= @message_thread.sender %>
               <% end %>
             </span>

--- a/app/components/message_threads_table_row_component.html.erb
+++ b/app/components/message_threads_table_row_component.html.erb
@@ -27,13 +27,9 @@
         <div class="flex flex-wrap gap-2 text-gray-500 text-xs md:text-base items-center">
           <% if @message_thread.sender || @message_thread.recipient %>
             <span class="text-left font-normal">
-              <% if @message_thread.box.communication_to_multiple_subjects? %>
-                <% if @message_thread.is_outbox && @message_thread.recipient.present? %>
-                  Komu: <%= @message_thread.recipient %>
-                <% elsif !@message_thread.is_outbox && @message_thread.sender.present? %>
-                  Od: <%= @message_thread.sender %>
-                <% end %>
-              <% elsif @message_thread.sender.present? %>
+              <% if MessageThreadHelper.show_recipient?(@message_thread) %>
+                Komu: <%= @message_thread.recipient %>
+              <% elsif MessageThreadHelper.show_sender?(@message_thread) %>
                 Od: <%= @message_thread.sender %>
               <% end %>
             </span>

--- a/app/helpers/message_thread_helper.rb
+++ b/app/helpers/message_thread_helper.rb
@@ -1,9 +1,9 @@
 module MessageThreadHelper
   def self.show_recipient?(message_thread)
-    message_thread.box.single_recipient? && message_thread.is_outbox && message_thread.recipient.present?
+    !message_thread.box.single_recipient? && message_thread.is_outbox && message_thread.recipient.present?
   end
 
   def self.show_sender?(message_thread)
-    !message_thread.box.single_recipient? || (!message_thread.is_outbox && message_thread.sender.present?)
+    message_thread.box.single_recipient? || (!message_thread.is_outbox && message_thread.sender.present?)
   end
 end

--- a/app/helpers/message_thread_helper.rb
+++ b/app/helpers/message_thread_helper.rb
@@ -1,0 +1,9 @@
+module MessageThreadHelper
+  def self.show_recipient?(message_thread)
+    message_thread.box.communication_to_multiple_subjects? && message_thread.is_outbox && message_thread.recipient.present?
+  end
+
+  def self.show_sender?(message_thread)
+    !message_thread.box.communication_to_multiple_subjects? || (!message_thread.is_outbox && message_thread.sender.present?)
+  end
+end

--- a/app/helpers/message_thread_helper.rb
+++ b/app/helpers/message_thread_helper.rb
@@ -1,9 +1,9 @@
 module MessageThreadHelper
   def self.show_recipient?(message_thread)
-    message_thread.box.communication_to_multiple_subjects? && message_thread.is_outbox && message_thread.recipient.present?
+    message_thread.box.single_recipient? && message_thread.is_outbox && message_thread.recipient.present?
   end
 
   def self.show_sender?(message_thread)
-    !message_thread.box.communication_to_multiple_subjects? || (!message_thread.is_outbox && message_thread.sender.present?)
+    !message_thread.box.single_recipient? || (!message_thread.is_outbox && message_thread.sender.present?)
   end
 end

--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -49,7 +49,7 @@ class Box < ApplicationRecord
     find_each(&:sync)
   end
 
-  def communication_to_multiple_subjects?
+  def single_recipient?
     raise NotImplementedError
   end
 

--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -49,6 +49,10 @@ class Box < ApplicationRecord
     find_each(&:sync)
   end
 
+  def communication_to_multiple_subjects?
+    raise NotImplementedError
+  end
+
   private
 
   def validate_box_with_api_connection

--- a/app/models/fs/box.rb
+++ b/app/models/fs/box.rb
@@ -41,7 +41,7 @@ class Fs::Box < Box
   end
 
   def single_recipient?
-    false
+    true
   end
 
   store_accessor :settings, :dic, prefix: true

--- a/app/models/fs/box.rb
+++ b/app/models/fs/box.rb
@@ -40,7 +40,7 @@ class Fs::Box < Box
   def sync
   end
 
-  def communication_to_multiple_subjects?
+  def single_recipient?
     false
   end
 

--- a/app/models/fs/box.rb
+++ b/app/models/fs/box.rb
@@ -40,6 +40,10 @@ class Fs::Box < Box
   def sync
   end
 
+  def communication_to_multiple_subjects?
+    false
+  end
+
   store_accessor :settings, :dic, prefix: true
   store_accessor :settings, :subject_id, prefix: true
 end

--- a/app/models/upvs/box.rb
+++ b/app/models/upvs/box.rb
@@ -46,7 +46,7 @@ class Upvs::Box < Box
     Govbox::SyncBoxJob.perform_later(self)
   end
 
-  def communication_to_multiple_subjects?
+  def single_recipient?
     true
   end
 

--- a/app/models/upvs/box.rb
+++ b/app/models/upvs/box.rb
@@ -47,7 +47,7 @@ class Upvs::Box < Box
   end
 
   def single_recipient?
-    true
+    false
   end
 
   private

--- a/app/models/upvs/box.rb
+++ b/app/models/upvs/box.rb
@@ -46,6 +46,10 @@ class Upvs::Box < Box
     Govbox::SyncBoxJob.perform_later(self)
   end
 
+  def communication_to_multiple_subjects?
+    true
+  end
+
   private
 
   def validate_settings_obo

--- a/test/system/fs/message_drafts_test.rb
+++ b/test/system/fs/message_drafts_test.rb
@@ -70,7 +70,7 @@ class Fs::MessageDraftsTest < ApplicationSystemTestCase
 
       within_thread_in_listing(message1.thread) do
         assert_text "Podanie pre FS (Správa daní) - platné od 1.4.2024"
-        assert_text "Finančná správa"
+        assert_text "Od: #{message1.thread.box.name}"
 
         within_tags do
           assert_text "Rozpracované"
@@ -79,7 +79,7 @@ class Fs::MessageDraftsTest < ApplicationSystemTestCase
 
       within_thread_in_listing(message2.thread) do
         assert_text "Vyhlásenie o poukázaní sumy do výšky 2% (3%) zaplatenej dane za zdaňovacie obdobie 2021"
-        assert_text "Finančná správa"
+        assert_text "Od: #{message2.thread.box.name}"
 
         within_tags do
           assert_text "Rozpracované"


### PR DESCRIPTION
Pri UPVS boxoch je mozna komunikacia ku viacerym subjektom, tak v pripade outboxovych sprav chceme na threade zobrazovat komu posledna outboxova sprava isla, inak odosielatela.
Pri FS boxoch je mozna komunikacia iba k jednemu subjektu (FS), tak chceme na threade zobrazovat vzdy odosielatela. 