### PR TITLE
GO-141 Do not inform user about message_draft diff in validations

### DIFF
--- a/app/jobs/fs/validate_message_draft_result_job.rb
+++ b/app/jobs/fs/validate_message_draft_result_job.rb
@@ -18,17 +18,11 @@ class Fs::ValidateMessageDraftResultJob < ApplicationJob
       }
 
       diff = response[:body]['problems']&.select { |problem| problem['level'] == 'diff' }
-      log("Message draft DIFF: #{diff.map{ |problem| problem['message']}.join(', ')}") if diff.any?
+      Rails.logger.info("Message draft DIFF: #{diff.map{ |problem| problem['message']}.join(', ')}") if diff.any?
 
       message_draft.add_cascading_tag(message_draft.tenant.submission_error_tag) if message_draft.metadata[:validation_errors][:errors].any? || message_draft.metadata[:validation_errors][:warnings].any?
     end
 
     message_draft.save
-  end
-
-  private
-
-  def log(message)
-    Rails.logger.info(message)
   end
 end

--- a/app/jobs/fs/validate_message_draft_result_job.rb
+++ b/app/jobs/fs/validate_message_draft_result_job.rb
@@ -25,7 +25,7 @@ class Fs::ValidateMessageDraftResultJob < ApplicationJob
 
     message_draft.save
   end
-  
+
   private
 
   def log(message)

--- a/app/jobs/fs/validate_message_draft_result_job.rb
+++ b/app/jobs/fs/validate_message_draft_result_job.rb
@@ -14,11 +14,21 @@ class Fs::ValidateMessageDraftResultJob < ApplicationJob
       message_draft.metadata[:validation_errors] = {
         result: response[:body]['result'],
         errors: response[:body]['problems']&.select { |problem| problem['level'] == 'error' }&.map{ |problem| problem['message'] },
-        warnings: response[:body]['problems']&.select { |problem| problem['level'] == 'warning' }&.map{ |problem| problem['message'] }
+        warnings: response[:body]['problems']&.select { |problem| problem['level'] == 'warning' }&.map{ |problem| problem['message'] },
       }
-      message_draft.add_cascading_tag(message_draft.tenant.submission_error_tag)
+
+      diff = response[:body]['problems']&.select { |problem| problem['level'] == 'diff' }
+      log("Message draft DIFF: #{diff.map{ |problem| problem['message']}.join(', ')}") if diff.any?
+
+      message_draft.add_cascading_tag(message_draft.tenant.submission_error_tag) if message_draft.metadata[:validation_errors][:errors].any? || message_draft.metadata[:validation_errors][:warnings].any?
     end
 
     message_draft.save
+  end
+  
+  private
+
+  def log(message)
+    Rails.logger.info(message)
   end
 end


### PR DESCRIPTION
Kedze nemame zanalyzovane, co vsetko sa v diffe moze vyskytovat a ako presne to chceme pouzivatelovi komunikovat, tak zatial by sme si to iba logovali a pouzivatelovi nic o diffe nehovorili.