### PR TITLE
GO-164 Do not retry Fs::DownloadSentMessageRelatedMessagesJob if NoRelatedMessagesError

### DIFF
--- a/app/jobs/fs/download_sent_message_related_messages_job.rb
+++ b/app/jobs/fs/download_sent_message_related_messages_job.rb
@@ -1,9 +1,9 @@
 module Fs
   class DownloadSentMessageRelatedMessagesJob < ApplicationJob
-    class NoRelatedMessagesError < StandardError
+    class MissingRelatedMessagesError < StandardError
     end
 
-    retry_on NoRelatedMessagesError, attempts: 1 do |_job, _error|
+    retry_on MissingRelatedMessagesError, attempts: 1 do |_job, _error|
       # no-op
     end
 
@@ -16,7 +16,7 @@ module Fs
       0.step do |k|
         received_messages = fs_api.fetch_received_messages(sent_message_id: outbox_message.metadata['fs_message_id'], page: k + 1, count: batch_size, from: from, to: to)
 
-        raise NoRelatedMessagesError if outbox_message.thread.messages.excluding(outbox_message).none? && received_messages['messages'].none? && outbox_message.delivered_at < 1.hour.ago
+        raise MissingRelatedMessagesError if outbox_message.thread.messages.excluding(outbox_message).none? && received_messages['messages'].none? && outbox_message.delivered_at < 1.hour.ago
 
         received_messages['messages'].each do |received_message|
           ::Fs::DownloadReceivedMessageJob.perform_later(received_message['message_id'], box: outbox_message.box)

--- a/app/jobs/fs/download_sent_message_related_messages_job.rb
+++ b/app/jobs/fs/download_sent_message_related_messages_job.rb
@@ -1,5 +1,12 @@
 module Fs
   class DownloadSentMessageRelatedMessagesJob < ApplicationJob
+    class NoRelatedMessagesError < StandardError
+    end
+
+    retry_on NoRelatedMessagesError, attempts: 1 do |_job, _error|
+      # no-op
+    end
+
     def perform(outbox_message, from: nil, to: nil, fs_client: FsEnvironment.fs_client, batch_size: 25)
       raise unless outbox_message.box.is_a?(Fs::Box)
       return unless outbox_message.box.syncable?
@@ -9,7 +16,7 @@ module Fs
       0.step do |k|
         received_messages = fs_api.fetch_received_messages(sent_message_id: outbox_message.metadata['fs_message_id'], page: k + 1, count: batch_size, from: from, to: to)
 
-        raise "No related messages!" if outbox_message.thread.messages.excluding(outbox_message).none? && received_messages['messages'].none? && outbox_message.delivered_at < 1.hour.ago
+        raise NoRelatedMessagesError if outbox_message.thread.messages.excluding(outbox_message).none? && received_messages['messages'].none? && outbox_message.delivered_at < 1.hour.ago
 
         received_messages['messages'].each do |received_message|
           ::Fs::DownloadReceivedMessageJob.perform_later(received_message['message_id'], box: outbox_message.box)

--- a/test/jobs/fs/download_sent_message_related_messages_job_test.rb
+++ b/test/jobs/fs/download_sent_message_related_messages_job_test.rb
@@ -12,7 +12,7 @@ class Fs::DownloadSentMessageRelatedMessagesJobTest < ActiveJob::TestCase
     **{sent_message_id: outbox_message.metadata['fs_message_id'], page: 1, count: 25, from: nil, to: nil}
 
     FsEnvironment.fs_client.stub :api, fs_api do
-      assert_raise(StandardError, match: /No related messages!/) do
+      assert_raise(Fs::DownloadSentMessageRelatedMessagesJob::NoRelatedMessagesError) do
         Fs::DownloadSentMessageRelatedMessagesJob.new.perform(outbox_message)
       end
     end

--- a/test/jobs/fs/download_sent_message_related_messages_job_test.rb
+++ b/test/jobs/fs/download_sent_message_related_messages_job_test.rb
@@ -12,7 +12,7 @@ class Fs::DownloadSentMessageRelatedMessagesJobTest < ActiveJob::TestCase
     **{sent_message_id: outbox_message.metadata['fs_message_id'], page: 1, count: 25, from: nil, to: nil}
 
     FsEnvironment.fs_client.stub :api, fs_api do
-      assert_raise(Fs::DownloadSentMessageRelatedMessagesJob::NoRelatedMessagesError) do
+      assert_raise(Fs::DownloadSentMessageRelatedMessagesJob::MissingRelatedMessagesError) do
         Fs::DownloadSentMessageRelatedMessagesJob.new.perform(outbox_message)
       end
     end


### PR DESCRIPTION
Sice sme spravili upravy v #517, job vyfailuje, ale retryuje sa. To nechceme, ved aj tak sync bezi kazde 2h, zbytocne tam tieto joby netocme dokola. Potrebujeme len, aby takyto job vyfailoval, nech vieme o tom, ze sa nieco deje.