### PR TITLE
GO-26 Fix some admin buttons with added border

### DIFF
--- a/app/components/settings/rules/actions_form_component.html.erb
+++ b/app/components/settings/rules/actions_form_component.html.erb
@@ -39,7 +39,7 @@
             <% end %>
             <div class="flex justify-start items-start self-stretch flex-grow-0 flex-shrink-0 gap-2 p-6">
               <%= rule_form.button "Späť", formaction: conditions_step_settings_automation_rule_path, class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md border border-gray-300 text-base font-medium text-left text-gray-900 bg-white" %>
-              <%= rule_form.button "Uložiť zmeny", class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md text-base font-medium text-left text-white bg-blue-600", data: { turbo_frame: "_top" } %>
+              <%= rule_form.button "Uložiť zmeny", class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md border text-base font-medium text-left text-white bg-blue-600", data: { turbo_frame: "_top" } %>
             </div>
           <% end %>
         </div>

--- a/app/components/settings/rules/conditions_form_component.html.erb
+++ b/app/components/settings/rules/conditions_form_component.html.erb
@@ -39,7 +39,7 @@
             <% end %>
             <div class="flex justify-start items-start self-stretch flex-grow-0 flex-shrink-0 gap-2 p-6">
               <%= rule_form.button "Späť", formaction: header_step_settings_automation_rule_path, class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md border border-gray-300 text-base font-medium text-left text-gray-900 bg-white" %>
-              <%= rule_form.button "Pokračovať", formaction: actions_step_settings_automation_rule_path, class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md text-base font-medium text-left text-white bg-blue-600" %>
+              <%= rule_form.button "Pokračovať", formaction: actions_step_settings_automation_rule_path, class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md border text-base font-medium text-left text-white bg-blue-600" %>
             </div>
           <% end %>
         </div>

--- a/app/components/settings/rules/rule_form_component.html.erb
+++ b/app/components/settings/rules/rule_form_component.html.erb
@@ -32,7 +32,7 @@
               <%= link_to settings_automation_rules_path, data: { turbo_frame: "_top" }, class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md bg-white border border-gray-300" do %>
                 <p class="flex-grow-0 flex-shrink-0 text-base font-medium text-left text-gray-900"> Zahodiť zmeny </p>
               <% end %>
-              <%= rule_form.button "Pokračovať", formaction: conditions_step_settings_automation_rule_path, class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md text-base font-medium text-left text-white bg-blue-600" %>
+              <%= rule_form.button "Pokračovať", formaction: conditions_step_settings_automation_rule_path, class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md text-base font-medium text-left text-white bg-blue-600 border" %>
             </div>
           <% end %>
         </div>

--- a/app/views/admin/automation_webhooks/_form.html.erb
+++ b/app/views/admin/automation_webhooks/_form.html.erb
@@ -35,7 +35,7 @@
             <%= link_to admin_tenant_automation_webhooks_path(Current.tenant), class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md bg-white border border-gray-300", data: { turbo_frame: "_top" } do %>
               <p class="flex-grow-0 flex-shrink-0 text-base font-medium text-left text-gray-900">Zahodiť</p>
             <% end %>
-            <%= form.button class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md bg-blue-600", data: { turbo_frame: "_top" } do %>
+            <%= form.button class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md bg-blue-600 border", data: { turbo_frame: "_top" } do %>
               <p class="flex-grow-0 flex-shrink-0 text-base font-medium text-left text-white"><%= @webhook.new_record? ? 'Vytvoriť' : 'Uložiť' %></p>
             <% end %>
           </div>


### PR DESCRIPTION
Isla som spisat tuto issue na GH, nech si moze niekto potiahnut, ale zistila som, ze rychlejsie to je rovno fixnut ako popisovat. Problem sa tykal admin modalov, kde su dve tlacidla vedla seba a jedno ma nastaveny border, druhe nie, tak to vizualne trochu bolo posunute. 