### PR TITLE
GO-166 Update content_match? conditions in Automation

### DIFF
--- a/app/models/automation/condition.rb
+++ b/app/models/automation/condition.rb
@@ -120,6 +120,7 @@ module Automation
       if object.pdf?
         pdf_match?(object.content, value)
       elsif object.xml?
+        # TODO: fix encoding when saving content to DB
         Nokogiri::XML(object.content, nil, 'UTF-8').to_s.match?(value)
       end
     end

--- a/app/models/automation/condition.rb
+++ b/app/models/automation/condition.rb
@@ -120,7 +120,7 @@ module Automation
       if object.pdf?
         pdf_match?(object.content, value)
       elsif object.xml?
-        object.content.match?(value)
+        Nokogiri::XML(object.content, nil, 'UTF-8').to_s.match?(value)
       end
     end
 

--- a/test/fixtures/automation/actions.yml
+++ b/test/fixtures/automation/actions.yml
@@ -32,3 +32,8 @@ six:
   automation_rule: five
   type: Automation::ChangeMessageThreadTitleAction
   value: "New title - {{title}}"
+
+seven:
+  automation_rule: six
+  type: Automation::AddMessageThreadTagAction
+  action_object: ssd_crac_success (Tag)

--- a/test/fixtures/automation/conditions.yml
+++ b/test/fixtures/automation/conditions.yml
@@ -31,3 +31,8 @@ six:
   automation_rule: five
   type: Automation::AttachmentContentContainsCondition
   value: "Test\\s*string"
+
+seven:
+  automation_rule: six
+  type: Automation::AttachmentContentContainsCondition
+  value: "úspešne spracovaná"

--- a/test/fixtures/automation/rules.yml
+++ b/test/fixtures/automation/rules.yml
@@ -29,3 +29,10 @@ five:
   tenant: ssd
   name: AttachmentContentContainsCondition
   trigger_event: message_created
+
+six:
+  user: basic
+  tenant: ssd
+  name: AttachmentContentContainsCondition2
+  trigger_event: message_created
+

--- a/test/fixtures/govbox/messages.yml
+++ b/test/fixtures/govbox/messages.yml
@@ -274,3 +274,28 @@ ssd_general_agenda_with_lorem_pdf:
         signed: true
         class: MyClass
         content: Dummy
+
+ssd_crac:
+  message_id: <%= SecureRandom.uuid %>
+  correlation_id: <%= SecureRandom.uuid %>
+  edesk_message_id: 100
+  delivered_at: <%= DateTime.current %>
+  edesk_class: TEST
+  folder: ssd_one
+  payload:
+    message_id: <%= SecureRandom.uuid %>
+    subject: MySubject
+    sender_name: MySender
+    sender_uri: MySenderURI
+    recipient_name: MyRecipient
+    delivered_at: <%= DateTime.current.to_s %>
+    original_html: MyHtml
+    objects:
+      - name: form
+        mime_type: application/x-eform-xml
+        signed: false
+        class: FORM
+        content: <ns6:InformationMessage xmlns:ns6="http://schemas.gov.sk/form/G2G.InformationMessage/1.3">
+          <ns6:Subject>Spracovanie po&#x17E;iadavky v registri autentifika&#x10D;n&#xFD;ch certifik&#xE1;tov</ns6:Subject>
+          <ns6:Text>&#x17D;iados&#x165; o zmenu z&#xE1;pisu autentifika&#x10D;n&#xE9;ho certifik&#xE1;tu v registri autentifika&#x10D;n&#xFD;ch certifik&#xE1;tov bola &#xFA;spe&#x161;ne spracovan&#xE1; 29.11.2024 13:00.</ns6:Text>
+          </ns6:InformationMessage>

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -74,6 +74,12 @@ ssd_print:
   visible: true
   tenant: ssd
 
+ssd_crac_success:
+  name: CRAC vybavené
+  type: SimpleTag
+  visible: true
+  tenant: ssd
+
 ssd_signature_requested:
   name: Na podpis
   type: SignatureRequestedTag

--- a/test/models/automation/rule_test.rb
+++ b/test/models/automation/rule_test.rb
@@ -68,4 +68,15 @@ class Automation::RuleTest < ActiveSupport::TestCase
     assert_includes message.thread.tags, tags(:ssd_print)
     assert_not_includes message.tags, tags(:ssd_print)
   end
+
+  test 'should run an automation on message created AttachmentContainsConidition AddMessageThreadTagAction' do
+    govbox_message = govbox_messages(:ssd_crac)
+
+    Govbox::Message.create_message_with_thread!(govbox_message)
+    travel_to(15.minutes.from_now) { GoodJob.perform_inline }
+    message = Message.last
+
+    assert_includes message.thread.tags, tags(:ssd_crac_success)
+    assert_not_includes message.tags, tags(:ssd_crac_success)
+  end
 end


### PR DESCRIPTION
Ukazalo sa, ze niektore XML, ktore prichadzaju z UPVS maju escapovanu diakritiku, co sposobilo problem pri matchovani obsahu priloh v automation, napr. ked chceme ku kazdej uspesnej registracii certifikatu na UPVS pridat Tag, hlada match na "úspešne spracovaná", pricom XML vyzera takto:

          <ns6:InformationMessage xmlns:ns6="http://schemas.gov.sk/form/G2G.InformationMessage/1.3">
            <ns6:Subject>Spracovanie po&#x17E;iadavky v registri autentifika&#x10D;n&#xFD;ch certifik&#xE1;tov</ns6:Subject>
            <ns6:Text>&#x17D;iados&#x165; o zmenu z&#xE1;pisu autentifika&#x10D;n&#xE9;ho certifik&#xE1;tu v registri autentifika&#x10D;n&#xFD;ch certifik&#xE1;tov bola &#xFA;spe&#x161;ne spracovan&#xE1; 29.11.2024 13:00.</ns6:Text>
          </ns6:InformationMessage>

Upravila som tak, aby sa matchovanie kontrolovalo voci UTF-8 XMLku.