### PR TITLE
Add thread_id to all message API endpoints

### DIFF
--- a/app/views/api/messages/search.json.jbuilder
+++ b/app/views/api/messages/search.json.jbuilder
@@ -1,4 +1,5 @@
 json.id @message.id
+json.thread_id @message.message_thread_id
 json.uuid @message.uuid
 json.title @message.title
 json.sender_name @message.sender_name

--- a/app/views/api/messages/show.json.jbuilder
+++ b/app/views/api/messages/show.json.jbuilder
@@ -1,4 +1,5 @@
 json.id @message.id
+json.thread_id @message.message_thread_id
 json.uuid @message.uuid
 json.title @message.title
 json.sender_name @message.sender_name

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -136,6 +136,9 @@ paths:
                   id:
                     description: Identifikátor správy v systéme Govbox Pro
                     type: integer
+                  thread_id:
+                    description: Identifikátor vlákna, ktorému prislúcha správa
+                    type: integer
                   uuid:
                     description: UUID správy
                     type: string
@@ -212,6 +215,9 @@ paths:
                 properties:
                   id:
                     description: Identifikátor správy v systéme Govbox Pro
+                    type: integer
+                  thread_id:
+                    description: Identifikátor vlákna, ktorému prislúcha správa
                     type: integer
                   uuid:
                     description: UUID správy


### PR DESCRIPTION
Is there any reason why the message `thread_id` is in the API `messages/sync` but not in `messages/{id}` and `messages/search`?

This PR consistently adds the `thread_id` to `messages/{id}` and `messages/search`. But it's possible I'm missing something and it's meant to be without it.

It's not fully tested yet, so it's a draft.