### PR TITLE
Add description attribute to message objects

### DIFF
--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -89,6 +89,7 @@ class Api::MessagesController < Api::TenantController
       ],
       objects: [
         :name,
+        :description,
         :is_signed,
         :to_be_signed,
         :mimetype,

--- a/app/jobs/govbox/submit_message_draft_job.rb
+++ b/app/jobs/govbox/submit_message_draft_job.rb
@@ -67,6 +67,7 @@ class Govbox::SubmitMessageDraftJob < ApplicationJob
       objects << {
         id: object.uuid,
         name: object.name,
+        description: object.description,
         encoding: "Base64",
         signed: object.is_signed,
         mime_type: object.mimetype,

--- a/app/models/message_object.rb
+++ b/app/models/message_object.rb
@@ -3,6 +3,7 @@
 # Table name: message_objects
 #
 #  id           :bigint           not null, primary key
+#  description  :string
 #  is_signed    :boolean
 #  mimetype     :string
 #  name         :string

--- a/db/migrate/20250114170638_add_description_to_message_objects.rb
+++ b/db/migrate/20250114170638_add_description_to_message_objects.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToMessageObjects < ActiveRecord::Migration[7.1]
+  def change
+    add_column :message_objects, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_09_184812) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_14_170638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -391,6 +391,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_09_184812) do
     t.boolean "is_signed"
     t.boolean "visualizable"
     t.uuid "uuid"
+    t.string "description"
     t.index ["message_id"], name: "index_message_objects_on_message_id"
   end
 

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -353,6 +353,10 @@ paths:
                         description: Názov objektu
                         type: string
                         nullable: true
+                      description:
+                        description: Popis objektu
+                        type: string
+                        nullable: true
                       is_signed:
                         description: Indikátor či je obsah objektu podpísaný
                         type: boolean
@@ -389,7 +393,6 @@ paths:
                         items:
                           type: string
                     required:
-                      - name
                       - mimetype
                       - is_signed
                       - object_type


### PR DESCRIPTION
Description atribut sme doteraz v GO nepouzivali, ale ukazalo sa, ze niekedy ho pri podaniach moze pouzivatel chciet vyplnit (podania cez API).