### PR TITLE
Enable choosing FS input XML files multiple times

### DIFF
--- a/app/javascript/controllers/dropzone_controller.js
+++ b/app/javascript/controllers/dropzone_controller.js
@@ -7,6 +7,8 @@ export default class extends Controller {
     const fileList = document.getElementById('fileList');
     const fileCount = document.getElementById('fileCount');
 
+    this.allFiles = new DataTransfer();
+
     dropzone.addEventListener('dragover', (e) => {
       e.preventDefault();
       dropzone.classList.add('border-blue-500', 'border-2');
@@ -32,9 +34,10 @@ export default class extends Controller {
 
   handleFiles(files) {
     const fileInput = document.getElementById('content[]');
-    fileInput.files = files;
 
     for (const file of files) {
+      this.allFiles.items.add(file);
+
       const listItem = document.createElement('div');
       listItem.textContent = `${file.name} (${this.formatBytes(file.size)})`;
       fileList.appendChild(listItem);
@@ -42,6 +45,8 @@ export default class extends Controller {
 
     fileCount.parentElement.classList.remove('hidden');
     fileCount.textContent = `${parseInt(fileCount.textContent) + files.length}`;
+
+    fileInput.files = this.allFiles.files;
   }
 
   formatBytes(bytes) {


### PR DESCRIPTION
Aktualne je potrebne vybrat vsetky XML subory na jedno otvorenie file upload dialogu. Dalsim otvorenim dialogu sa subory prepisuju, co robi klientovi problem, nakolko subory ma roztriedene v roznych priecinkoch a potrebuje to tam postupne povyberat.
Tu je pripraveny update, aby sa subory neprepisovali, ale pridavali.