### PR TITLE
Do not allow to add FS boxes manually

### DIFF
--- a/app/controllers/admin/boxes/fs_boxes_controller.rb
+++ b/app/controllers/admin/boxes/fs_boxes_controller.rb
@@ -1,19 +1,4 @@
 class Admin::Boxes::FsBoxesController < Admin::BoxesController
-  def new
-    @box = Current.tenant.boxes.new(type: "Fs::Box")
-    authorize([:admin, @box])
-  end
-
-  def create
-    @box = Current.tenant.boxes.new(type: "Fs::Box", uri: "dic://sk/#{box_params.require(:settings_dic)}", **box_params)
-    authorize([:admin, @box])
-    if @box.save!
-      redirect_to admin_tenant_boxes_url(Current.tenant), notice: "Box was successfully created."
-    else
-      render :new, status: :unprocessable_entity
-    end
-  end
-
   def update
     authorize([:admin, @box])
     if @box.update(uri: "dic://sk/#{box_params.require(:settings_dic)}", **box_params)

--- a/app/views/admin/boxes/index.html.erb
+++ b/app/views/admin/boxes/index.html.erb
@@ -37,11 +37,6 @@
     <div class="self-stretch bg-white rounded-md border border-gray-200 flex-col justify-start items-start flex">
       <div class="self-stretch p-6 border-b border-gray-200 justify-start items-center gap-4 inline-flex">
         <div class="grow shrink basis-0 text-gray-900 text-xl font-semibold leading-[35px]">FS Schránky</div>
-        <% if Current.tenant.api_connections.where(type: "Fs::ApiConnection").any? %>
-          <%= link_to new_admin_tenant_boxes_fs_box_path, data: { turbo_frame: "modal" }, class: "px-3.5 py-2.5 bg-blue-600 rounded-md justify-center items-center gap-2.5 flex" do %>
-            <p class="text-white text-base font-medium leading-normal">Pripojiť novú schránku</p>
-          <% end %>
-        <% end %>
       </div>
       <% if @boxes.where(type: "Fs::Box").any? %>
         <div class="self-stretch flex-col justify-start items-start flex">


### PR DESCRIPTION
Maly fix. Tlacidlo pripojit novu schranku nema v adminovi vyznam, moze maximalne sposobit problemy.
Vytvaranie schranok chceme povolit iba na zaklade existujucich zastupovani ku ApiConnection, co sa deje automaticky. Takze nie je potreba ziadne FS schranky pridavat este bokom.