### PR TITLE
GO-199 Update 'Typ dokumentu' value in FS DeliveryReport visualisation

### DIFF
--- a/app/models/fs/message.rb
+++ b/app/models/fs/message.rb
@@ -80,6 +80,7 @@ class Fs::Message
         "fs_submission_status": raw_message['submission_status'],
         "fs_message_type": raw_message.dig('message_container', 'message_type'),
         "fs_submission_type_id": raw_message['submission_type_id'], # TODO kde pouzit? asi napr. pri vytvarani nazvu suboru pri exporte
+        "fs_submission_type_name": raw_message['submission_type_name'],
         "fs_submission_created_at": Time.zone.parse(raw_message['submission_created_at']),
         "fs_period": raw_message['period'],
         "fs_dismissal_reason": raw_message['dismissal_reason'],

--- a/app/views/fs/messages/_delivery_report.html.erb
+++ b/app/views/fs/messages/_delivery_report.html.erb
@@ -5,7 +5,7 @@
     <tr>
       <th>Typ dokumentu:</th>
       <td>
-        <b><%= message.title %></b>
+        <b><%= message.metadata.dig('fs_submission_type_name') || message.title %></b>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Ukazalo sa, ze vo vizualizacii FS potvrdeniek neuvadzame pre atribut 'Typ dokumentu' zhodnu hodnotu s FS portalom. Podla mna spatne spravy aktualizovat nie je potrebne (kto stahuje, riesi potvrdenky to uz ma stiahnute v povodnej podobe).