### PR TITLE
GO-202 Mark some UPVS forms as not downloadable

### DIFF
--- a/app/jobs/upvs/download_form_related_documents_job.rb
+++ b/app/jobs/upvs/download_form_related_documents_job.rb
@@ -1,6 +1,8 @@
 module Upvs
   class DownloadFormRelatedDocumentsJob < ApplicationJob
     def perform(upvs_form, downloader: ::Upvs::FormRelatedDocumentsDownloader)
+      return unless upvs_form.downloadable?
+
       upvs_form_downloader = downloader.new(upvs_form)
 
       upvs_form_downloader.download_related_document_by_type(:xsd)

--- a/app/models/upvs/form.rb
+++ b/app/models/upvs/form.rb
@@ -2,11 +2,12 @@
 #
 # Table name: upvs_forms
 #
-#  id         :bigint           not null, primary key
-#  identifier :string           not null
-#  version    :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id           :bigint           not null, primary key
+#  downloadable :boolean          default(TRUE)
+#  identifier   :string           not null
+#  version      :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
 #
 class Upvs::Form < ApplicationRecord
   has_many :related_documents, class_name: 'Upvs::FormRelatedDocument', foreign_key: 'upvs_form_id', dependent: :destroy

--- a/db/migrate/20250205125502_add_downloadable_to_upvs_forms.rb
+++ b/db/migrate/20250205125502_add_downloadable_to_upvs_forms.rb
@@ -1,0 +1,7 @@
+class AddDownloadableToUpvsForms < ActiveRecord::Migration[7.1]
+  def change
+    add_column :upvs_forms, :downloadable, :boolean, default: true
+
+    Upvs::Form.where(identifier: ['ks_352538', 'ks_362431']).update_all(downloadable: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_14_170638) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_05_125502) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -605,6 +605,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_14_170638) do
     t.string "version", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "downloadable", default: true
     t.index ["identifier", "version"], name: "index_forms_on_identifier_version", unique: true
   end
 


### PR DESCRIPTION
Mame zopar UPVS formularov, ktore su specialnymi pripadmi (ORSR formulare), ktore nemaju bezne identifikatory ako zvysne UPVS formulare a nie su dostupne na ulozisku formularov.
Formulare sa ale v GO vyuzivaju a pravidelne stahovanie updateov k formularom nam failuje pri tychto specialitkach. Updaty k nim stahovat standardnym sposobom nechceme.
Chceme, aby nam to nefailovalo, zbytocne nas to "zaslepuje" pred realne problematickymi jobmi.