### PR TITLE
GO-181 Create InboxTag in order to filter only delivered significant messages

### DIFF
--- a/app/jobs/add_inbox_tag_to_thread_job.rb
+++ b/app/jobs/add_inbox_tag_to_thread_job.rb
@@ -6,6 +6,6 @@ class AddInboxTagToThreadJob < ApplicationJob
   private
 
   def significant_inbox_message?(message)
-    !message.outbox? && !Govbox::Message::INFORMATIONAL_MESSAGE_CLASSES.include?(message.metadata.dig('edesk_class'))
+    !message.outbox? && !Govbox::Message::INSIGNIFICANT_MESSAGE_CLASSES.include?(message.metadata.dig('edesk_class'))
   end
 end

--- a/app/jobs/add_inbox_tag_to_thread_job.rb
+++ b/app/jobs/add_inbox_tag_to_thread_job.rb
@@ -1,0 +1,11 @@
+class AddInboxTagToThreadJob < ApplicationJob
+  def perform(message_thread)
+    message_thread.assign_tag(message_thread.tenant.inbox_tag) if message_thread.messages.any?{ |message| significant_inbox_message?(message) }
+  end
+
+  private
+
+  def significant_inbox_message?(message)
+    !message.outbox? && !Govbox::Message::INFORMATIONAL_MESSAGE_CLASSES.include?(message.metadata.dig('edesk_class'))
+  end
+end

--- a/app/jobs/add_inbox_tag_to_threads_job.rb
+++ b/app/jobs/add_inbox_tag_to_threads_job.rb
@@ -1,0 +1,5 @@
+class AddInboxTagToThreadsJob < ApplicationJob
+  def perform
+    MessageThread.find_each { |message_thread| AddInboxTagToThreadJob.perform_later(message_thread) }
+  end
+end

--- a/app/models/govbox/message.rb
+++ b/app/models/govbox/message.rb
@@ -20,7 +20,7 @@ class Govbox::Message < ApplicationRecord
 
   EGOV_DOCUMENT_CLASS = 'EGOV_DOCUMENT'
   EGOV_NOTIFICATION_CLASS = 'EGOV_NOTIFICATION'
-  COLLAPSED_BY_DEFAULT_MESSAGE_CLASSES = ['ED_DELIVERY_REPORT', 'POSTING_CONFIRMATION', 'POSTING_INFORMATION']
+  INFORMATIONAL_MESSAGE_CLASSES = ['ED_DELIVERY_REPORT', 'POSTING_CONFIRMATION', 'POSTING_INFORMATION']
   GENERAL_AGENDA_SCHEMA = 'http://schemas.gov.sk/form/App.GeneralAgenda/1.9'
 
   DELIVERY_NOTIFICATION_TAG = 'delivery_notification'
@@ -39,6 +39,7 @@ class Govbox::Message < ApplicationRecord
         title: message.metadata.dig("delivery_notification", "consignment", "subject").presence || message.title,
         delivered_at: govbox_message.delivered_at
       )
+      message.thread.assign_tag(message.thread.tenant.inbox_tag) if !message.outbox? && !govbox_message.insignificant?
 
       message.save!
 
@@ -66,7 +67,15 @@ class Govbox::Message < ApplicationRecord
   end
 
   def collapsed?
-    payload["class"].in?(COLLAPSED_BY_DEFAULT_MESSAGE_CLASSES)
+    insignificant?
+  end
+
+  def read?
+    folder.outbox? || insignificant?
+  end
+
+  def insignificant?
+    payload["class"].in?(INFORMATIONAL_MESSAGE_CLASSES)
   end
 
   def delivery_notification
@@ -97,6 +106,7 @@ class Govbox::Message < ApplicationRecord
       replyable: govbox_message.replyable?,
       collapsed: govbox_message.collapsed?,
       outbox: govbox_message.folder.outbox?,
+      read: govbox_message.read?,
       metadata: {
         "correlation_id": govbox_message.payload["correlation_id"],
         "reference_id": govbox_message.payload["reference_id"],

--- a/app/models/govbox/message.rb
+++ b/app/models/govbox/message.rb
@@ -20,7 +20,7 @@ class Govbox::Message < ApplicationRecord
 
   EGOV_DOCUMENT_CLASS = 'EGOV_DOCUMENT'
   EGOV_NOTIFICATION_CLASS = 'EGOV_NOTIFICATION'
-  INFORMATIONAL_MESSAGE_CLASSES = ['ED_DELIVERY_REPORT', 'POSTING_CONFIRMATION', 'POSTING_INFORMATION']
+  INSIGNIFICANT_MESSAGE_CLASSES = ['ED_DELIVERY_REPORT', 'POSTING_CONFIRMATION', 'POSTING_INFORMATION']
   GENERAL_AGENDA_SCHEMA = 'http://schemas.gov.sk/form/App.GeneralAgenda/1.9'
 
   DELIVERY_NOTIFICATION_TAG = 'delivery_notification'
@@ -75,7 +75,7 @@ class Govbox::Message < ApplicationRecord
   end
 
   def insignificant?
-    payload["class"].in?(INFORMATIONAL_MESSAGE_CLASSES)
+    payload["class"].in?(INSIGNIFICANT_MESSAGE_CLASSES)
   end
 
   def delivery_notification

--- a/app/models/govbox/message.rb
+++ b/app/models/govbox/message.rb
@@ -39,7 +39,7 @@ class Govbox::Message < ApplicationRecord
         title: message.metadata.dig("delivery_notification", "consignment", "subject").presence || message.title,
         delivered_at: govbox_message.delivered_at
       )
-      message.thread.assign_tag(message.thread.tenant.inbox_tag) if !message.outbox? && !govbox_message.insignificant?
+      message.thread.assign_tag(message.thread.tenant.inbox_tag) if !message.outbox? && govbox_message.significant?
 
       message.save!
 
@@ -67,15 +67,15 @@ class Govbox::Message < ApplicationRecord
   end
 
   def collapsed?
-    insignificant?
+    !significant?
   end
 
   def read?
-    folder.outbox? || insignificant?
+    folder.outbox? || !significant?
   end
 
-  def insignificant?
-    payload["class"].in?(INSIGNIFICANT_MESSAGE_CLASSES)
+  def significant?
+    !payload["class"].in?(INSIGNIFICANT_MESSAGE_CLASSES)
   end
 
   def delivery_notification

--- a/app/models/inbox_tag.rb
+++ b/app/models/inbox_tag.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id               :bigint           not null, primary key
+#  color            :enum
+#  external_name    :string
+#  icon             :string
+#  name             :string           not null
+#  tag_groups_count :integer          default(0), not null
+#  type             :string           not null
+#  visible          :boolean          default(TRUE), not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  owner_id         :bigint
+#  tenant_id        :bigint           not null
+#
+class InboxTag < Tag
+  def destroyable?
+    false
+  end
+end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -20,6 +20,7 @@ class Tenant < ApplicationRecord
 
   has_one :draft_tag, -> { where(owner_id: nil) }
   has_one :everything_tag
+  has_one :inbox_tag
   has_one :signature_requested_tag
   has_one :signed_tag
   has_one :signed_externally_tag
@@ -117,6 +118,7 @@ class Tenant < ApplicationRecord
 
     create_draft_tag!(name: "Rozpracované", visible: true)
     create_everything_tag!(name: "Všetky správy", visible: false)
+    create_inbox_tag!(name: "Doručené", visible: false)
     create_archived_tag!(name: "Archivované", color: "green", icon: "archive-box", visible: true)
     create_signature_requested_tag!(name: "Na podpis", visible: true, color: "yellow", icon: "pencil")
     create_signed_tag!(name: "Podpísané", visible: true, color: "green", icon: "fingerprint")

--- a/db/migrate/20250204074342_create_inbox_tag.rb
+++ b/db/migrate/20250204074342_create_inbox_tag.rb
@@ -1,0 +1,12 @@
+class CreateInboxTag < ActiveRecord::Migration[7.1]
+  def up
+    Tenant.find_each do |tenant|
+      tenant.create_inbox_tag!(name: "Doručené", visible: false) unless tenant.inbox_tag
+      AddInboxTagToThreadsJob.set(job_context: :later).perform_later
+    end
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_14_170638) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_04_074342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/test/fixtures/govbox/messages.yml
+++ b/test/fixtures/govbox/messages.yml
@@ -323,7 +323,7 @@ ssd_done_new:
         class: FORM
         content: Dummy
 
-ssd_posting_confirmation:
+ssd_main_done_posting_confirmation:
   message_id: <%= SecureRandom.uuid %>
   correlation_id: d2d6ab13-347e-49f4-9c3b-0b8390430870
   edesk_message_id: 102
@@ -339,6 +339,98 @@ ssd_posting_confirmation:
     delivered_at: <%= DateTime.current.to_s %>
     original_html: MyHtml
     class: POSTING_CONFIRMATION
+    objects:
+      - name: form
+        mime_type: application/x-eform-xml
+        signed: false
+        class: FORM
+        content: Dummy
+
+ssd_egov_application:
+  message_id: <%= SecureRandom.uuid %>
+  correlation_id: f932fd8b-c996-4eb8-ba6c-af7714ef4069
+  edesk_message_id: 103
+  delivered_at: <%= DateTime.current %>
+  edesk_class: EGOV_APPLICATION
+  folder: ssd_sent
+  payload:
+    message_id: <%= SecureRandom.uuid %>
+    subject: MySubject
+    sender_name: MySender
+    sender_uri: MySenderURI
+    recipient_name: MyRecipient
+    delivered_at: <%= DateTime.current.to_s %>
+    original_html: MyHtml
+    class: EGOV_APPLICATION
+    objects:
+      - name: form
+        mime_type: application/x-eform-xml
+        signed: false
+        class: FORM
+        content: Dummy
+
+ssd_posting_confirmation:
+  message_id: <%= SecureRandom.uuid %>
+  correlation_id: f932fd8b-c996-4eb8-ba6c-af7714ef4069
+  edesk_message_id: 104
+  delivered_at: <%= DateTime.current %>
+  edesk_class: POSTING_CONFIRMATION
+  folder: ssd_one
+  payload:
+    message_id: <%= SecureRandom.uuid %>
+    subject: MySubject
+    sender_name: MySender
+    sender_uri: MySenderURI
+    recipient_name: MyRecipient
+    delivered_at: <%= DateTime.current.to_s %>
+    original_html: MyHtml
+    class: POSTING_CONFIRMATION
+    objects:
+      - name: form
+        mime_type: application/x-eform-xml
+        signed: false
+        class: FORM
+        content: Dummy
+
+ssd_delivery_report:
+  message_id: <%= SecureRandom.uuid %>
+  correlation_id: f932fd8b-c996-4eb8-ba6c-af7714ef4069
+  edesk_message_id: 105
+  delivered_at: <%= DateTime.current %>
+  edesk_class: ED_DELIVERY_REPORT
+  folder: ssd_one
+  payload:
+    message_id: <%= SecureRandom.uuid %>
+    subject: MySubject
+    sender_name: MySender
+    sender_uri: MySenderURI
+    recipient_name: MyRecipient
+    delivered_at: <%= DateTime.current.to_s %>
+    original_html: MyHtml
+    class: ED_DELIVERY_REPORT
+    objects:
+      - name: form
+        mime_type: application/x-eform-xml
+        signed: false
+        class: FORM
+        content: Dummy
+
+ssd_egov_document:
+  message_id: <%= SecureRandom.uuid %>
+  correlation_id: f932fd8b-c996-4eb8-ba6c-af7714ef4069
+  edesk_message_id: 106
+  delivered_at: <%= DateTime.current %>
+  edesk_class: EGOV_DOCUMENT
+  folder: ssd_one
+  payload:
+    message_id: <%= SecureRandom.uuid %>
+    subject: MySubject
+    sender_name: MySender
+    sender_uri: MySenderURI
+    recipient_name: MyRecipient
+    delivered_at: <%= DateTime.current.to_s %>
+    original_html: MyHtml
+    class: EGOV_DOCUMENT
     objects:
       - name: form
         mime_type: application/x-eform-xml

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -44,6 +44,12 @@ ssd_everything:
   visible: false
   tenant: ssd
 
+ssd_inbox:
+  name: Inbox
+  type: InboxTag
+  visible: false
+  tenant: ssd
+
 ssd_signed_externally:
   name: SignedExternally
   type: SignedExternallyTag
@@ -187,6 +193,12 @@ solver_everything:
   visible: false
   tenant: solver
 
+solver_inbox:
+  name: Inbox
+  type: InboxTag
+  visible: false
+  tenant: solver
+
 ssd_basic_user_drafts:
   name: Drafts-Basic user
   owner: basic
@@ -237,6 +249,12 @@ accountants_drafts:
 accountants_everything:
   name: Everything
   type: EverythingTag
+  visible: false
+  tenant: accountants
+
+accountants_inbox:
+  name: Inbox
+  type: InboxTag
   visible: false
   tenant: accountants
 

--- a/test/models/automation/rule_test.rb
+++ b/test/models/automation/rule_test.rb
@@ -111,7 +111,7 @@ class Automation::RuleTest < ActiveSupport::TestCase
   test 'should not run an automation on message created outbox BooleanCondition, edesk_class MessageMetadataValueNotCondition UnassignMessageThreadTagAction if POSTING_CONFIRMATION delivered' do
     tag = tags(:ssd_done)
     message_thread = message_threads(:ssd_main_done)
-    govbox_message = govbox_messages(:ssd_posting_confirmation)
+    govbox_message = govbox_messages(:ssd_main_done_posting_confirmation)
 
     govbox_message.update_column(:correlation_id, 'd2d6ab13-347e-49f4-9c3b-0b8390430870')
 


### PR DESCRIPTION
Co chceme dosiahnut:
- aby vlakno bolo oznacene za neprecitane iba ak pride plnohodnotna inboxova sprava
- aby vlakna, ktore obsahuju aspon jednu plnohodnotnu inboxovu spravu boli oznacene Inboxovym stitkom (ten je aktualne schovany, ale umoznuje vytvorit filter "Doručené", kt. sa správa podobne ako v gmaili).

Potrebujeme to preto, aby po odosielani podani sa nenasypalo do GO velke mnozstvo odoslanych sprav, ktore sa tvaria ako nove a treba ich otvorit a vyhodnotit (ci to je nieco na spracovanie).