### PR TITLE
GO-181 Add Inbox Tag to thread when new FS inbox message is processed

### DIFF
--- a/app/models/fs/message.rb
+++ b/app/models/fs/message.rb
@@ -9,6 +9,7 @@ class Fs::Message
       message = create_inbox_message(raw_message)
 
       message.thread = associated_outbox_message.thread
+      message.thread.assign_tag(message.thread.tenant.inbox_tag)
 
       message.save!
 

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -309,6 +309,7 @@ fs_accountants_outbox:
   replyable: false
   metadata:
     fs_message_id: 1234/2024
+    correlation_id: 4bc972bb-9364-47de-bb40-23720f24a4ab
   author: accountants_basic
 
 solver_main_delivery_notification_one:

--- a/test/models/fs/message_test.rb
+++ b/test/models/fs/message_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 require "active_support/all"
 
 class Fs::MessageTest < ActiveSupport::TestCase
-  test "#create_inbox_messages creates new message with delivered_at and fs_submission_created_at values in same format" do
+  test "#create_inbox_message creates new message with delivered_at and fs_submission_created_at values in same format" do
     raw_message = {
       "created_at" => "2024-06-05T10:27:03.105Z",
       "message_id" => "12345689/2024",
@@ -50,5 +50,52 @@ class Fs::MessageTest < ActiveSupport::TestCase
 
     assert_equal '2024-06-05 12:27:03 +0200', message.delivered_at.to_s
     assert_equal '2024-06-05T12:27:01.433+02:00', message.metadata['fs_submission_created_at']
+  end
+
+  test "#create_inbox_message_with_thread handles adding inbox tag to thread" do
+    raw_message = {
+      "created_at" => "2024-06-05T10:27:03.105Z",
+      "message_id" => "12345689/2024",
+      "submission_type_id" => "3079",
+      "submission_type_name" => "Podanie pre FS  (Správa daní) – späťvzatie žiadosti",
+      "message_type_id" => "DRSR_POPP_v02",
+      "message_type_name" => "Informácia o podaní",
+      "sent_message_id" => "1234/2024",
+      "seen" => true,
+      "is_ekr2" => true,
+      "status" => "Vybavená",
+      "submission_status" => "Prijaté a potvrdené",
+      "dic" => "1122222333",
+      "subject" => "xy",
+      "submitting_subject" => "xy",
+      "submission_created_at" => "2024-06-05T10:27:01.433Z",
+      "period" => nil,
+      "dismissal_reason" => nil,
+      "message_container" =>
+        {
+          "message_id" => SecureRandom.uuid,
+          "sender_id" => "FSSR",
+          "recipient_id" => "1122222333",
+          "message_type" => "ED.DeliveryReport",
+          "subject" => "x",
+          "objects" => [
+            {
+              "class" => "FORM",
+              "description" => "DeliveryReport",
+              "encoding" => "XML",
+              "id" => SecureRandom.uuid,
+              "signed" => true,
+              "mime_type" => "application/xml",
+              "name" => "DeliveryReport",
+              "content" =>
+                "<content>xy</content>"
+            }
+          ]
+        }
+    }
+
+    Fs::Message.create_inbox_message_with_thread!(raw_message, box: boxes(:fs_accountants))
+
+    assert Message.last.thread.tags.include?(tags(:accountants_inbox))
   end
 end


### PR DESCRIPTION
V #546 sme vyriesili oznacenie existujucich sprav (UPVS, aj FS) inboxovym tagom + oznacovanie novych UPVS sprav pri spracovani, na nove FS spravy sa pozadublo. Tak pridavam.
Logika je jednoducha, ked sa stiahne inboxova sprava, pridavame tag na vlakno.