### PR TITLE
GO-206 Make message export file names unique

### DIFF
--- a/app/helpers/message_object_helper.rb
+++ b/app/helpers/message_object_helper.rb
@@ -10,13 +10,4 @@ module MessageObjectHelper
   def self.base_name(message_object)
     message_object.name.present? ? File.basename(message_object.name, File.extname(message_object.name)) : I18n.t('no_message_object_name')
   end
-
-  def self.unique_name_within_message(message_object, other_file_names, pdf: false)
-    file_name = self.base_name(message_object)
-    matches_count = other_file_names.count { |name| /#{file_name}( \(\d+\))?\.\w*/ =~ name }
-
-    file_name += " (#{matches_count})" if matches_count > 0
-
-    file_name + (pdf ? '.pdf' : File.extname(message_object.name))
-  end
 end

--- a/app/helpers/message_object_helper.rb
+++ b/app/helpers/message_object_helper.rb
@@ -10,4 +10,13 @@ module MessageObjectHelper
   def self.base_name(message_object)
     message_object.name.present? ? File.basename(message_object.name, File.extname(message_object.name)) : I18n.t('no_message_object_name')
   end
+
+  def self.unique_name_within_message(message_object, other_file_names, pdf: false)
+    file_name = self.base_name(message_object)
+    matches_count = other_file_names.count { |name| /#{file_name}( \(\d+\))?\.\w*/ =~ name }
+
+    file_name += " (#{matches_count})" if matches_count > 0
+
+    file_name + (pdf ? '.pdf' : File.extname(message_object.name))
+  end
 end

--- a/app/models/concerns/message_export_operations.rb
+++ b/app/models/concerns/message_export_operations.rb
@@ -21,7 +21,7 @@ module MessageExportOperations
 
     def prepare_original_objects(zip, file_names)
       objects.each do |message_object|
-        file_name = MessageObjectHelper.unique_name_within_message(message_object, file_names)
+        file_name = unique_name_within_message(message_object, file_names)
         zip.put_next_entry("originaly/#{file_name}")
         zip.write(message_object.content)
         file_names << file_name
@@ -39,7 +39,7 @@ module MessageExportOperations
 
           raise StandardError, "Unable to prepare PDF visualization for MessageObject ID #{message_object.id}" unless pdf_content
 
-          file_name = MessageObjectHelper.unique_name_within_message(message_object, file_names, pdf: true)
+          file_name = unique_name_within_message(message_object, file_names, pdf: true)
           zip.put_next_entry(file_name)
           zip.write(pdf_content)
           file_names << file_name
@@ -58,11 +58,20 @@ module MessageExportOperations
           raise StandardError, "Unable to prepare PDF visualization for MessageObject ID #{nested_message_object.id}" unless pdf_content
         end
 
-        file_name = MessageObjectHelper.unique_name_within_message(nested_message_object, file_names, pdf: true)
+        file_name = unique_name_within_message(nested_message_object, file_names, pdf: true)
         zip.put_next_entry(file_name)
         zip.write(pdf_content)
         file_names << file_name
       end
+    end
+
+    def unique_name_within_message(message_object, other_file_names, pdf: false)
+      file_name = MessageObjectHelper.base_name(message_object)
+      matches_count = other_file_names.count { |name| /#{file_name}( \(\d+\))?\.\w*/ =~ name }
+
+      file_name += " (#{matches_count})" if matches_count > 0
+
+      file_name + (pdf ? '.pdf' : File.extname(message_object.name))
     end
   end
 end


### PR DESCRIPTION
Ukazal sa problem s pripadom, kedy v ramci jednej spravy mozu mat objekty (alebo vnorene objekty v asice) rovnake nazvy.
Konkretne nam klient nahlasil pripad, kedy v exporte chyba jeden subor, lebo objekty su taketo:

form.asice
 - form.xml
 
priloha1.asice
 - **dokument.pdf**

priloha2.asice
-  **dokument.pdf**

Dvakrat tam je dokument.pdf, takze v exporte sa tie subory prepisu. Nazvy suborov som uplne nechcela kazit nejakym IDckom objektu, tak som sa snazila dorobit _(1), (2)_,... oznacovanie v nazvoch suborov pri exporte, aby teda tieto dva vnorene objekty v exporte mali nazvy: 
- dokument.pdf, dokument (1).pdf