### PR TITLE
Make UUID_PATERN case insensitive

### DIFF
--- a/app/lib/utils.rb
+++ b/app/lib/utils.rb
@@ -1,7 +1,7 @@
 module Utils
   extend self
 
-  UUID_PATTERN = %r{\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z}
+  UUID_PATTERN = %r{\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z}i
   EXTENSIONS_ALLOW_LIST = %w(pdf xml asice asics xzep zip txt doc docx jpg jpeg png tif tiff)
 
   MIMETYPES_ALLOW_LIST = %w(application/x-eform-xml application/xml application/msword application/pdf application/vnd.etsi.asic-e+zip application/vnd.etsi.asic-s+zip application/vnd.openxmlformats-officedocument.wordprocessingml.document application/x-xades_zep application/x-zip-compressed image/jpg image/jpeg text/xml image/png image/tiff application/pkix-cert)


### PR DESCRIPTION
Pri pridavani schranok zo zoznamu UPVS opravneni na zastupovanie bol problem s tym, ze uuid je uppercase, tak uuid bolo vyhodnotene za nevalidne.