### PR TITLE
GO-209 Preserve succeeded good jobs for 1 day

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,7 @@ module GovboxPro
 
     config.good_job.enable_cron = true
     config.good_job.smaller_number_is_higher_priority = true
-    config.good_job.cleanup_preserved_jobs_before_seconds_ago = 0.minutes
+    config.good_job.cleanup_preserved_jobs_before_seconds_ago = 1.days
     config.good_job.cleanup_discarded_jobs = false
 
     if ENV['AUTO_SYNC_BOXES'] == "ON"


### PR DESCRIPTION
Aby sme sa vyhli zmazaniu vsetkeho predtym, ako sa dokonci cely batch jobov, potrebujeme ich na nejaky cas uchovavat. Naschval som nastavila hodnotu na 1 den a nie na iba minuty/hodinu, lebo moze ist aj o vacsie, dlhsie trvajuce joby v ramci jedneho batchu, napr. import draftov z velkeho balika.