### PR TITLE
GO-231 try fetching messages without delegate if empty

### DIFF
--- a/app/jobs/fs/download_sent_message_related_messages_job.rb
+++ b/app/jobs/fs/download_sent_message_related_messages_job.rb
@@ -16,6 +16,10 @@ module Fs
       0.step do |k|
         received_messages = fs_api.fetch_received_messages(sent_message_id: outbox_message.metadata['fs_message_id'], page: k + 1, count: batch_size, from: from, to: to)
 
+        if received_messages['messages'].none?
+          received_messages = fs_api.fetch_received_messages(sent_message_id: outbox_message.metadata['fs_message_id'], page: k + 1, count: batch_size, from: from, to: to, obo: fs_api.obo_without_delegate)
+        end
+
         raise MissingRelatedMessagesError if outbox_message.thread.messages.excluding(outbox_message).none? && received_messages['messages'].none? && outbox_message.delivered_at < 1.hour.ago
 
         received_messages['messages'].each do |received_message|

--- a/app/lib/fs/api.rb
+++ b/app/lib/fs/api.rb
@@ -2,6 +2,8 @@
 
 module Fs
   class Api
+    attr_accessor :obo, :obo_without_delegate
+
     def initialize(url, api_connection: nil, box: nil, handler: Faraday)
       @url = url
       @handler = handler
@@ -84,8 +86,8 @@ module Fs
     private
 
     def initialize_obo(box)
-      @obo = "#{box.settings_subject_id}:#{box.settings_dic}"
-      @obo += ":#{box.settings_delegate_id}" if box.settings_delegate_id
+      @obo_without_delegate = "#{box.settings_subject_id}:#{box.settings_dic}"
+      @obo = @obo_without_delegate + (box.settings_delegate_id ? ":#{box.settings_delegate_id}" : "")
     end
 
     def jwt_header(obo = nil)

--- a/test/jobs/fs/download_sent_message_related_messages_job_test.rb
+++ b/test/jobs/fs/download_sent_message_related_messages_job_test.rb
@@ -24,4 +24,32 @@ class Fs::DownloadSentMessageRelatedMessagesJobTest < ActiveJob::TestCase
       end
     end
   end
+
+  test "does not raise error if related messages for outbox_message found with obo without delegate" do
+    outbox_message = messages(:fs_accountants_outbox)
+
+    fs_api = Minitest::Mock.new
+    fs_api.expect :obo_without_delegate, "obo_without_delegate"
+    fs_api.expect :fetch_received_messages, {
+      "count" => 0,
+      "messages" => []
+    },
+    **{sent_message_id: outbox_message.metadata['fs_message_id'], page: 1, count: 25, from: nil, to: nil}
+
+    fs_api.expect :fetch_received_messages, {
+      "count" => 1,
+      "messages" => [
+        {
+          "message_id" => "12345"
+        }
+      ]
+    },
+    **{sent_message_id: outbox_message.metadata['fs_message_id'], page: 1, count: 25, from: nil, to: nil, obo: "obo_without_delegate"}
+
+    FsEnvironment.fs_client.stub :api, fs_api do
+      assert_enqueued_with(job: Fs::DownloadReceivedMessageJob) do
+        Fs::DownloadSentMessageRelatedMessagesJob.new.perform(outbox_message)
+      end
+    end
+  end
 end

--- a/test/jobs/fs/download_sent_message_related_messages_job_test.rb
+++ b/test/jobs/fs/download_sent_message_related_messages_job_test.rb
@@ -5,11 +5,18 @@ class Fs::DownloadSentMessageRelatedMessagesJobTest < ActiveJob::TestCase
     outbox_message = messages(:fs_accountants_outbox)
 
     fs_api = Minitest::Mock.new
+    fs_api.expect :obo_without_delegate, "obo_without_delegate"
     fs_api.expect :fetch_received_messages, {
       "count" => 0,
       "messages" => []
     },
     **{sent_message_id: outbox_message.metadata['fs_message_id'], page: 1, count: 25, from: nil, to: nil}
+
+    fs_api.expect :fetch_received_messages, {
+      "count" => 0,
+      "messages" => []
+    },
+    **{sent_message_id: outbox_message.metadata['fs_message_id'], page: 1, count: 25, from: nil, to: nil, obo: "obo_without_delegate"}
 
     FsEnvironment.fs_client.stub :api, fs_api do
       assert_raise(Fs::DownloadSentMessageRelatedMessagesJob::MissingRelatedMessagesError) do


### PR DESCRIPTION
V zozname prijatých jednu správu nevidno, ak sa pošle delegate_id. Vidno je ale práve bez neho. Stiahnuť sa tá konkrétna správa dá aj s delegate_id v obo.

Historicky nastal jeden takýto prípad, odkedy používame delegate_id (čo je asi dva mesiace). Takýto fix asi stojí za to - vyčistí nám healthcheck.