### PR TITLE
Add uri to uniqueness scope of FS Box name

### DIFF
--- a/app/models/fs/box.rb
+++ b/app/models/fs/box.rb
@@ -20,7 +20,8 @@ class Fs::Box < Box
 
   before_create { self.syncable = tenant.feature_enabled?(:fs_sync) }
 
-  validates_uniqueness_of :name, :short_name, scope: :tenant_id
+  validates_uniqueness_of :short_name, scope: [:tenant_id]
+  validates_uniqueness_of :name, scope: [:tenant_id, :uri]
 
   def self.policy_class
     BoxPolicy

--- a/test/models/fs/box_test.rb
+++ b/test/models/fs/box_test.rb
@@ -31,4 +31,95 @@ class Fs::BoxTest < ActiveSupport::TestCase
 
     assert_not box.reload.syncable
   end
+
+  test "validates uniqueness of name scoped to tenant_id and uri" do
+    tenant = tenants(:accountants)
+    api_connection = api_connections(:fs_api_connection1)
+
+    # Create original box
+    Fs::Box.create!(
+      name: "Unique Box Name",
+      short_name: "UBN",
+      uri: "dic://sk/123456789",
+      tenant: tenant,
+      api_connection: api_connection
+    )
+
+    # Should fail with same name, tenant_id, and uri
+    duplicate_box = Fs::Box.new(
+      name: "Unique Box Name",
+      short_name: "Different",
+      uri: "dic://sk/123456789",
+      tenant: tenant,
+      api_connection: api_connection
+    )
+    assert_not duplicate_box.valid?
+    assert_includes duplicate_box.errors[:name], "Názov ste už použili"
+
+    # Should succeed with same name, same tenant, but different uri
+    different_uri_box = Fs::Box.new(
+      name: "Unique Box Name",
+      short_name: "Different",
+      uri: "dic://sk/987654321",
+      tenant: tenant,
+      api_connection: api_connection
+    )
+    assert different_uri_box.valid?
+
+    # Should succeed with same name, same uri, but different tenant
+    different_tenant_box = Fs::Box.new(
+      name: "Unique Box Name",
+      short_name: "Different",
+      uri: "dic://sk/123456789",
+      tenant: tenants(:solver),
+      api_connection: api_connections(:fs_api_connection2)
+    )
+    assert different_tenant_box.valid?
+  end
+
+  test "validates uniqueness of short_name scoped to tenant_id" do
+    tenant = tenants(:accountants)
+    api_connection = api_connections(:fs_api_connection1)
+
+    # Create original box
+    Fs::Box.create!(
+      name: "Original Box",
+      short_name: "OB",
+      uri: "dic://sk/123456789",
+      tenant: tenant,
+      api_connection: api_connection
+    )
+
+    # Should fail with same short_name, tenant_id, and uri
+    duplicate_box = Fs::Box.new(
+      name: "Different Name",
+      short_name: "OB",
+      uri: "dic://sk/123456789",
+      tenant: tenant,
+      api_connection: api_connection
+    )
+    assert_not duplicate_box.valid?
+    assert_includes duplicate_box.errors[:short_name], "Krátky názov ste už použili"
+
+    # Should fail with same short_name, same tenant even if different uri
+    different_uri_box = Fs::Box.new(
+      name: "Different Name",
+      short_name: "OB",
+      uri: "dic://sk/987654321",
+      tenant: tenant,
+      api_connection: api_connection
+    )
+    assert_not different_uri_box.valid?
+    assert_includes different_uri_box.errors[:short_name], "Krátky názov ste už použili"
+
+    # Should succeed with same short_name, same uri, but different tenant
+    different_tenant_box = Fs::Box.new(
+      name: "Different Name",
+      short_name: "OB",
+      uri: "dic://sk/123456789",
+      tenant: tenants(:solver),
+      api_connection: api_connections(:fs_api_connection2)
+    )
+    assert different_tenant_box.valid?
+  end
 end


### PR DESCRIPTION
Short name is supposed to be unique for a tenant. Name can be the same, if the uri is different.

closes #581 