### PR TITLE
Add Automation::ValueCondition

### DIFF
--- a/app/models/automation/condition.rb
+++ b/app/models/automation/condition.rb
@@ -38,6 +38,20 @@ module Automation
     end
   end
 
+  class ValueCondition < Automation::Condition
+    validates :value, presence: true
+    VALID_ATTR_LIST = %w[type].freeze
+    validates :attr, inclusion: { in: VALID_ATTR_LIST }
+
+    def satisfied?(thing)
+      thing[attr] == value
+    end
+
+    def cleanup_record
+      self.condition_object = nil
+    end
+  end
+
   class ContainsCondition < Automation::Condition
     validates :value, presence: true
     VALID_ATTR_LIST = %w[sender_name recipient_name title object_type].freeze

--- a/test/models/automation/rule_test.rb
+++ b/test/models/automation/rule_test.rb
@@ -141,4 +141,25 @@ class Automation::RuleTest < ActiveSupport::TestCase
     message_draft = Fs::MessageDraft.last
     assert_includes message_draft.thread.tags, tags(:api_connection_tag)
   end
+
+  test 'does not run an automation unless ValueCondition satisfied' do
+    author = users(:accountants_basic)
+
+    rule = automation_rules(:add_tag_api_connection)
+    rule.conditions.create(type: "Automation::ValueCondition", attr: "type", value: "Message")
+
+    fs_api = Minitest::Mock.new
+    fs_api.expect :parse_form, {
+      "subject" => "1122334455",
+      "form_identifier" => "3055_781"
+    },
+                  [file_fixture("fs/dic1122334455_fs3055_781__sprava_dani_2023.xml").read]
+
+    FsEnvironment.fs_client.stub :api, fs_api do
+        Fs::MessageDraft.create_and_validate_with_fs_form(form_files: [fixture_file_upload("fs/dic1122334455_fs3055_781__sprava_dani_2023.xml", "application/xml")], author: author)
+    end
+    travel_to(15.minutes.from_now) { GoodJob.perform_inline }
+    message_draft = Fs::MessageDraft.last
+    assert_not_includes message_draft.thread.tags, tags(:api_connection_tag)
+  end
 end


### PR DESCRIPTION
Potrebujeme kvoli vyzadovaniu podpisov. Povodne sme mysleli, ze bude stacit condition na connection, ale nie je to tak, potrebujeme kontrolovat aj typ spravy, aby sa podpisy vyzadovali iba na draftoch, nie plnohodnotnych spravach.