### PR TITLE
Add metadata to search message response

### DIFF
--- a/app/views/api/messages/search.json.jbuilder
+++ b/app/views/api/messages/search.json.jbuilder
@@ -6,6 +6,7 @@ json.sender_name @message.sender_name
 json.recipient_name @message.recipient_name
 json.delivered_at @message.delivered_at
 json.status @message.metadata.dig('status') if @message.metadata.dig('status').present?
+json.metadata @message.metadata
 
 json.objects @message.objects do |object|
   json.name object.name

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -296,6 +296,13 @@ paths:
                           description: Samotný objektu zakódovaný ako Base64 text
                           type: string
                           format: byte
+                  metadata:
+                    description: Metaúdaje správy
+                    oneOf:
+                      - type:
+                        $ref: '#/components/schemas/FsMessageMetadata'
+                      - type:
+                        $ref: '#/components/schemas/UpvsMessageMetadata'
       security:
         - "Tenant_Token": []
 


### PR DESCRIPTION
Ako sme na meetingu riesili tento endpoint som si v API specifikacii vsimla, ze search endpoint nevracia metadata (kt. sme nedavno pridavali do endpointu na ziskanie detailu spravy).