### PR TITLE
Remove Problemove tag after submission

### DIFF
--- a/app/jobs/fs/submit_message_draft_result_job.rb
+++ b/app/jobs/fs/submit_message_draft_result_job.rb
@@ -5,6 +5,7 @@ class Fs::SubmitMessageDraftResultJob < ApplicationJob
     if 200 == response[:status]
       message_draft.submitted!
       message_draft.metadata[:fs_message_id] = response[:body]['sent_message_id']
+      message_draft.remove_cascading_tag(message_draft.tenant.submission_error_tag)
       message_draft.save
 
       ::Fs::DownloadSentMessageJob.perform_later(response[:body]['sent_message_id'], box: message_draft.box)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -58,7 +58,7 @@ class Message < ApplicationRecord
 
   def remove_cascading_tag(tag)
     messages_tags.find_by(tag: tag)&.destroy
-    thread.message_threads_tags.find_by(tag: tag)&.destroy unless thread.messages.any? {|m| m.tags.include?(tag) }
+    thread.message_threads_tags.find_by(tag: tag)&.destroy unless thread.messages.reload.any? {|m| m.tags.include?(tag) }
   end
 
   def draft?


### PR DESCRIPTION
Pri FS jobe sme Problemove tag po odoslani nemazali vobec (t.j. podanie, kt. malo napr. iba logicke chyby je aj po odoslani stale oznacene Problemove tagom) a pri UPVS jobe sice mazanie mame, ale chybal v metode `reload`, aby to zafungovalo.