### PR TITLE
GO-249 Schedule FS sync job with wait statement

### DIFF
--- a/app/jobs/fs/sync_all_boxes_job.rb
+++ b/app/jobs/fs/sync_all_boxes_job.rb
@@ -1,8 +1,8 @@
 module Fs
   class SyncAllBoxesJob < ApplicationJob
     def perform
-      Fs::Box.where(syncable: true).find_each do |box|
-        SyncBoxJob.perform_later(box)
+      Fs::Box.where(syncable: true).find_each.with_index do |box, index|
+        SyncBoxJob.set(wait: index*0.5.seconds).perform_later(box)
       end
 
       BetterUptimeApi.ping_heartbeat('FS_SYNC')


### PR DESCRIPTION
Zaroven ponechavame aj `perform_limit` v samotnom sync jobe, aby sme to vedeli limitovat aj tam, predislo "kopeniu".