### PR TITLE
GO-261 Add message object ID to message show response

### DIFF
--- a/app/views/api/messages/search.json.jbuilder
+++ b/app/views/api/messages/search.json.jbuilder
@@ -7,8 +7,10 @@ json.recipient_name @message.recipient_name
 json.delivered_at @message.delivered_at
 json.status @message.metadata.dig('status') if @message.metadata.dig('status').present?
 json.metadata @message.metadata
+json.tags @message.tags.pluck(:name)
 
 json.objects @message.objects do |object|
+  json.id object.id
   json.name object.name
   json.mimetype object.mimetype
   json.object_type object.object_type

--- a/app/views/api/messages/show.json.jbuilder
+++ b/app/views/api/messages/show.json.jbuilder
@@ -10,6 +10,7 @@ json.metadata @message.metadata
 json.tags @message.tags.pluck(:name)
 
 json.objects @message.objects do |object|
+  json.id object.id
   json.name object.name
   json.mimetype object.mimetype
   json.object_type object.object_type

--- a/app/views/api/messages/sync.json.jbuilder
+++ b/app/views/api/messages/sync.json.jbuilder
@@ -7,8 +7,11 @@ json.array! @messages do |message|
   json.recipient_name message.recipient_name
   json.delivered_at message.delivered_at
   json.status message.metadata.dig('status') if message.metadata.dig('status').present?
+  json.metadata message.metadata
+  json.tags message.tags.pluck(:name)
 
   json.objects message.objects do |object|
+    json.id object.id
     json.name object.name
     json.mimetype object.mimetype
     json.object_type object.object_type

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -181,6 +181,9 @@ paths:
                       description: Objekt správy
                       type: object
                       properties:
+                        id:
+                          description: Identifikátor objektu v systéme Govbox Pro
+                          type: integer
                         name:
                           description: Názov objektu
                           type: string
@@ -281,6 +284,9 @@ paths:
                       description: Objekt správy
                       type: object
                       properties:
+                        id:
+                          description: Identifikátor objektu v systéme Govbox Pro
+                          type: integer
                         name:
                           description: Názov objektu
                           type: string
@@ -403,6 +409,9 @@ paths:
                         description: Objekt správy
                         type: object
                         properties:
+                          id:
+                            description: Identifikátor objektu v systéme Govbox Pro
+                            type: integer
                           name:
                             description: Názov objektu
                             type: string

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -277,6 +277,20 @@ paths:
                     description: Aktuálny stav správy
                     type: string
                     enum: [ "being_loaded", "being_validated", "invalid", "created", "being_submitted", "temporary_submit_fail", "submit_fail", "submitted" ]
+                  metadata:
+                    description: Metaúdaje správy
+                    oneOf:
+                      - type:
+                        $ref: '#/components/schemas/FsMessageMetadata'
+                      - type:
+                        $ref: '#/components/schemas/UpvsMessageMetadata'
+                  tags:
+                    description: Zoznam štítkov priradených správe
+                    type: array
+                    items:
+                      description: Názov štítka priradeného správe
+                      type:
+                        string
                   message_objects:
                     description: Zoznam objektov správy
                     type: array
@@ -308,13 +322,6 @@ paths:
                           description: Samotný objektu zakódovaný ako Base64 text
                           type: string
                           format: byte
-                  metadata:
-                    description: Metaúdaje správy
-                    oneOf:
-                      - type:
-                        $ref: '#/components/schemas/FsMessageMetadata'
-                      - type:
-                        $ref: '#/components/schemas/UpvsMessageMetadata'
       security:
         - "Tenant_Token": []
 
@@ -402,6 +409,20 @@ paths:
                       description: Aktuálny stav správy
                       type: string
                       enum: [ "being_loaded", "being_validated", "invalid", "created", "being_submitted", "temporary_submit_fail", "submit_fail", "submitted" ]
+                    metadata:
+                      description: Metaúdaje správy
+                      oneOf:
+                        - type:
+                          $ref: '#/components/schemas/FsMessageMetadata'
+                        - type:
+                          $ref: '#/components/schemas/UpvsMessageMetadata'
+                    tags:
+                      description: Zoznam štítkov priradených správe
+                      type: array
+                      items:
+                        description: Názov štítka priradeného správe
+                        type:
+                          string
                     message_objects:
                       description: Zoznam objektov správy
                       type: array

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -174,7 +174,7 @@ paths:
                     items:
                       description: Názov štítka priradeného správe
                       type: string
-                  message_objects:
+                  objects:
                     description: Zoznam objektov správy
                     type: array
                     items:
@@ -291,7 +291,7 @@ paths:
                       description: Názov štítka priradeného správe
                       type:
                         string
-                  message_objects:
+                  objects:
                     description: Zoznam objektov správy
                     type: array
                     items:
@@ -423,7 +423,7 @@ paths:
                         description: Názov štítka priradeného správe
                         type:
                           string
-                    message_objects:
+                    objects:
                       description: Zoznam objektov správy
                       type: array
                       items:

--- a/test/integration/messages_api_test.rb
+++ b/test/integration/messages_api_test.rb
@@ -23,6 +23,7 @@ class ThreadsApiTest < ActionDispatch::IntegrationTest
     assert_equal message.tags.first.name, json_response["tags"][0]
     assert_equal message.tags.second.name, json_response["tags"][1]
     message.objects.each do |object|
+      assert_equal object.id, json_response["objects"][0]["id"]
       assert_equal object.name, json_response["objects"][0]["name"]
       assert_equal object.mimetype, json_response["objects"][0]["mimetype"]
       assert_equal object.object_type, json_response["objects"][0]["object_type"]
@@ -63,6 +64,7 @@ class ThreadsApiTest < ActionDispatch::IntegrationTest
     assert_equal message.delivered_at, Time.zone.parse(json_response["delivered_at"])
     assert_equal message.metadata["status"], json_response["status"]
     message.objects.each do |object|
+      assert_equal object.id, json_response["objects"][0]["id"]
       assert_equal object.name, json_response["objects"][0]["name"]
       assert_equal object.mimetype, json_response["objects"][0]["mimetype"]
       assert_equal object.object_type, json_response["objects"][0]["object_type"]


### PR DESCRIPTION
V https://github.com/slovensko-digital/govbox-pro/pull/619 sme pridali moznost ziskat PDF vizualizaciu objektu spravy. Zabudlo sa vsak na to, ze ID objektu v ziadnych responses nevraciame. Tak som ID pridala vsade, kde objekty vraciame a rovno som zjednotila som responsy k detailu spravy (kedze tam v poslednej dobe nieco pribudalo a nebolo to uplne jednotne na vsetkych 3 endpointoch, cez ktore sa da ziskat detail spravy).