### PR TITLE
Update API specification: fix messages metadata fs_form_id type & Specify Fs::MessageDraft metadata

### DIFF
--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -167,6 +167,8 @@ paths:
                       - type:
                         $ref: '#/components/schemas/FsMessageMetadata'
                       - type:
+                        $ref: '#/components/schemas/FsMessageDraftMetadata'
+                      - type:
                         $ref: '#/components/schemas/UpvsMessageMetadata'
                   tags:
                     description: Zoznam štítkov priradených správe
@@ -282,6 +284,8 @@ paths:
                     oneOf:
                       - type:
                         $ref: '#/components/schemas/FsMessageMetadata'
+                      - type:
+                        $ref: '#/components/schemas/FsMessageDraftMetadata'
                       - type:
                         $ref: '#/components/schemas/UpvsMessageMetadata'
                   tags:
@@ -414,6 +418,8 @@ paths:
                       oneOf:
                         - type:
                           $ref: '#/components/schemas/FsMessageMetadata'
+                        - type:
+                          $ref: '#/components/schemas/FsMessageDraftMetadata'
                         - type:
                           $ref: '#/components/schemas/UpvsMessageMetadata'
                     tags:
@@ -1177,7 +1183,21 @@ components:
           type: string
         fs_form_id:
           description: Interný identifikátor FS formulára
+          type: integer
+        status:
+          description: Aktuálny stav správy
           type: string
+          enum: ["being_loaded", "being_validated", "invalid", "created", "being_submitted", "temporary_submit_fail", "submit_fail", "submitted"]
+
+    FsMessageDraftMetadata:
+      description: Metaúdaje rozpracovanej správy Finančnej správy
+      properties:
+        dic:
+          description: DIČ
+          type: string
+        fs_form_id:
+          description: Interný identifikátor FS formulára
+          type: integer
         correlation_id:
           description: Identifikátor vlákna správ
           type: string
@@ -1185,6 +1205,23 @@ components:
           description: Aktuálny stav správy
           type: string
           enum: ["being_loaded", "being_validated", "invalid", "created", "being_submitted", "temporary_submit_fail", "submit_fail", "submitted"]
+        validation_errors:
+          description: Validačné errory správy
+          type: object
+          properties:
+            result:
+              description: Výsledok validácie správy
+              type: string
+            errors:
+              description: Validačné errory
+              type: array
+              items:
+                type: string
+            warnings:
+              description: Validačné upozornenia (logické chyby)
+              type: array
+              items:
+                type: string
 
     UpvsMessageMetadata:
       description: Metaúdaje správy ÚPVS

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1075,6 +1075,7 @@ components:
             correlation_id:
               description: Identifikátor vlákna správ
               type: string
+              format: uuid
           required:
             - correlation_id
         objects:
@@ -1201,6 +1202,7 @@ components:
         correlation_id:
           description: Identifikátor vlákna správ
           type: string
+          format: uuid
         status:
           description: Aktuálny stav správy
           type: string
@@ -1241,6 +1243,7 @@ components:
         correlation_id:
           description: SKTalk identifikátor vlákna správ
           type: string
+          format: uuid
         reference_id:
           description: SKTalk identifikátor referenčnej správy
           type: string


### PR DESCRIPTION
`Fs::MessageDraft` ma trochu ine metadata ako uz plnohodnotna `Message` a integrujuci klient ma s tym trochu problem, nevie ake atributy moze pri drafte ocakavat a ktore sa naopak tykaju iba plnohodnotnych sprav.
Dorobila som teda zvlast typ pre `Fs::MessageDraft` metadata, nech v tom je poriadok.