### PR TITLE
GO-137 Do not match UPVS form for FS EdDelivery reports

### DIFF
--- a/app/models/concerns/pdf_visualization_operations.rb
+++ b/app/models/concerns/pdf_visualization_operations.rb
@@ -73,6 +73,7 @@ module PdfVisualizationOperations
 
     def form
       return unless xml?
+      return if message.metadata.dig("fs_message_type").present?
 
       xml_document = xml_unsigned_content
       # TODO forms without posp_id, posp_versions


### PR DESCRIPTION
Vo vseobecnosti, v core plati, ze chceme generovat PDF vizualizaciu XMLka z XSL-FO ak existuje. Ak nie, tak chceme PDF generovat z GO HTML vizualizacie.
FS potvrdenky su ale vynimkou. Tam XSL-FO existuje, lebo FS potvrdenky vyuzivaju rovnaky formular ako je v UPVS svete, ale nechceme ho matchnut na FS spravu. Nechceme to, lebo vizualizacia v FS svete je ina. 
Takze mam takyto skaredy fix, aby sa k FS spravam nematchoval UPVS formular.