### PR TITLE
GO-137 Update export files naming

### DIFF
--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -47,10 +47,10 @@ class Export < ApplicationRecord
 
     default_template = settings.dig("templates", "default").presence || DEFAULT_TEMPLATE
 
-    if settings.dig('by_form', form).present?
-      template = settings.dig("templates", form).presence || default_template
-    elsif settings.dig('by_type', type).present?
+    if settings.dig('by_type', type).present?
       template = settings.dig("templates", type).presence || default_template
+    elsif settings.dig('by_form', form).present?
+      template = settings.dig("templates", form).presence || default_template
     elsif settings['default'].present?
       template = default_template
     else


### PR DESCRIPTION
Prehodila som priority pomenovania. Mame teraz 3 urovne:
- pomenovanie podla typu formulara
- pomenovanie podla typu spravy
- default

Podla priority by to malo byt takto:
- pomenovanie podla typu spravy (aby bolo mozne pomenovat potvrdenku inak ako podanie - to je hlavna poziadavka)
- pomenovanie podla typu formulara (aby napr. SVDPH podania mohli byt pomenove SV alebo akokolvek inak podla zelania klienta)
- default