### PR TITLE
GO-259 Multiple API connections

### DIFF
--- a/app/models/fs/api_connection.rb
+++ b/app/models/fs/api_connection.rb
@@ -55,7 +55,7 @@ class Fs::ApiConnection < ::ApiConnection
     fs_api.get_subjects.each do |subject|
       Fs::Box.with_advisory_lock!("boxify-#{tenant_id}", transaction: true, timeout_seconds: 10) do
         boxes = Fs::Box.where(tenant: tenant).where("settings @> ?", {dic: subject["dic"], subject_id: subject["subject_id"]}.to_json)
-        box = boxes.select{ |box| box.settings_delegate_id == subject["delegate_id"] }
+        box = boxes.select { |box| (box.settings_delegate_id == subject["delegate_id"]) || (box.api_connection == self) }.first if boxes.any?
 
         unless box
           box = Fs::Box.new(


### PR DESCRIPTION
Nastal problem v mapovani schranok, api connections, ak ich existuje viacero. Konkretny pripad je: 
- tenant ma 3 API connections (3 uctovnici opravneni podavat)
- opravnenie na zastupovanie konkretneho klienta existuje v 2 roznych podobach (s `delegate_id` a bez) - to sa lisi u jednotlivych uctovnikov, niektori to maju pridelene tak, ini inak

Jedna sa o rovnaky subjekt, ale rozne sposoby zastupovania. Otazka teraz znie: ma to byt v GO iba jedna schranka alebo dve? Vzhladom na sposob zastupovania

Toto este nechavam chvilu vo vzduchu na premyslenie. Nejake upravy som tu navrhla (ktore by znamenali, ze to budu dve rozne schranky), ale toto si najprv musime prejst @jsuchal.