### PR TITLE
GO-288/summary-export-format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'stimulus-rails'
 gem 'jsbundling-rails'
 gem 'pdf-reader'
 gem 'grover'
+gem 'caxlsx'
 
 # Monitoring
 gem 'rollbar'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,11 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
+    caxlsx (4.2.0)
+      htmlentities (~> 4.3, >= 4.3.4)
+      marcel (~> 1.0)
+      nokogiri (~> 1.10, >= 1.10.4)
+      rubyzip (>= 1.3.0, < 3)
     clockwork (3.0.2)
       activesupport
       tzinfo
@@ -174,6 +179,7 @@ GEM
     hashery (2.1.2)
     hashie (5.0.0)
     htmlbeautifier (1.4.2)
+    htmlentities (4.3.4)
     http-accept (1.7.0)
     http-cookie (1.0.5)
       domain_name (~> 0.5)
@@ -513,6 +519,7 @@ DEPENDENCIES
   brakeman
   capybara
   capybara-screenshot
+  caxlsx
   clockwork
   dotenv-rails
   erb_lint

--- a/app/views/message_threads/bulk/exports/edit.html.erb
+++ b/app/views/message_threads/bulk/exports/edit.html.erb
@@ -101,7 +101,7 @@
               <td class="whitespace-nowrap py-2 pl-4 pr-3 text-sm text-gray-500 sm:pl-0">-</td>
               <td class="px-2 py-2 text-sm font-medium text-gray-900">Sumár</td>
               <td class="whitespace-nowrap px-2 py-2 text-sm text-gray-900">-</td>
-              <td class="whitespace-nowrap px-2 py-2 text-sm text-gray-500">sumár.csv</td>
+              <td class="whitespace-nowrap px-2 py-2 text-sm text-gray-500">sumar.xlsx</td>
             </tr>
           <% end %>
 


### PR DESCRIPTION
PR k issue [GO-288](https://sluzbyslovenskodigital.atlassian.net/browse/GO-288)
Pôvodny test export vo formáte .csv: [sumár.csv](https://github.com/user-attachments/files/22021660/sumar.csv)
Nový test export vo formáte .xlsx: [sumar.xlsx](https://github.com/user-attachments/files/22021661/sumar.xlsx)

Note: vybral som gem, ktorý je stále podporovaný a má aj všelijaké funkcie na modifikáciu sheetov, ak by to bolo v budúcnosti potrebné...