### PR TITLE
GO-296 Do FS API calls with same API connection in all FS submission jobs

### DIFF
--- a/app/jobs/fs/submit_message_draft_result_job.rb
+++ b/app/jobs/fs/submit_message_draft_result_job.rb
@@ -4,7 +4,7 @@ class Fs::SubmitMessageDraftResultJob < ApplicationJob
   end
 
   def perform(message_draft, location_header, fs_client: FsEnvironment.fs_client)
-    response = fs_client.api(box: message_draft.thread.box).get_location(location_header)
+    response = fs_client.api(box: message_draft.thread.box, api_connection: message_draft.find_api_connection_for_submission).get_location(location_header)
 
     if 200 == response[:status]
       message_draft.submitted!

--- a/app/jobs/fs/submit_message_draft_status_job.rb
+++ b/app/jobs/fs/submit_message_draft_status_job.rb
@@ -1,6 +1,6 @@
 class Fs::SubmitMessageDraftStatusJob < ApplicationJob
   def perform(message_draft, location_header, fs_client: FsEnvironment.fs_client)
-    response = fs_client.api(box: message_draft.thread.box).get_location(location_header)
+    response = fs_client.api(box: message_draft.thread.box, api_connection: message_draft.find_api_connection_for_submission).get_location(location_header)
 
     if response[:headers][:retry_after]
       Fs::SubmitMessageDraftStatusJob.set(wait: response[:headers][:retry_after].to_i.seconds).perform_later(message_draft, location_header)


### PR DESCRIPTION
Chceme, aby sa requesty na dopytovanie stavu submissionu volali s rovnakym FS API connection, ako pri vytvarani submissionu.