### PR TITLE
GO-297 Set ZIP unicode filenames to true

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ if ['development', 'test'].include? ENV['RAILS_ENV']
   Dotenv::Rails.load
 end
 
+Zip.unicode_names = true
+
 module GovboxPro
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
Po analyze problemu a odskusani na Windowse sa zda, ze toto nastavenie pre zip gem by malo vyriesit problem.