### PR TITLE
GO-300 Add datum_dorucenia variable to exports

### DIFF
--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -26,7 +26,8 @@ class Export < ApplicationRecord
     "{{ vlakno.obdobie }}" => ->(o) { o.message.thread.metadata["period"] if o.message.thread.metadata&.dig("period") },
     "{{ vlakno.formular }}" => ->(o) { form_name(o) },
     "{{ vlakno.formular_bez_verzie }}" => ->(o) { form_name(o, include_version: false) },
-    "{{ vlakno.datum_podania }}" => ->(o) { o.message.thread.messages.outbox.first.delivered_at&.to_date },
+    "{{ vlakno.datum_podania }}" => ->(o) { o.message.thread.messages.outbox&.first&.delivered_at&.to_date },
+    "{{ vlakno.datum_dorucenia }}" => ->(o) { o.message.delivered_at.to_date },
     "{{ sprava.id }}" => ->(o) { o.message.id },
     "{{ subor.nazov }}" => ->(o) { o.name }
   }.freeze

--- a/app/views/message_threads/bulk/exports/edit.html.erb
+++ b/app/views/message_threads/bulk/exports/edit.html.erb
@@ -48,6 +48,7 @@
                   <code>{{ vlakno.formular }}</code> – typ formulára s verziou (napr. DPHv20)<br>
                   <code>{{ vlakno.formular_bez_verzie }}</code> – typ formulára bez verzie (napr. DPH)<br>
                   <code>{{ vlakno.datum_podania }}</code> – dátum podania<br>
+                  <code>{{ vlakno.datum_dorucenia }}</code> – dátum doručenia správy<br>
                   <code>{{ sprava.id }}</code> – identifikátor správy<br>
                   <code>{{ subor.nazov }}</code> – názov súboru (napr. priloha.pdf)
                 </div>


### PR DESCRIPTION
Pri exporte pouzivatela castokrat zaujima datum danej spravy a su tu podla mna dva rozne pripady:

- Pri FS podaniach zaujima pouzivatela datum podania (datum odoslanej spravy),
- Pri UPVS spravach zaujima datum dorucenia konkretnej spravy. 

Preto navrhujem takuto upravu. 