### PR TITLE
Fix LOG_LEVEL ENV name

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
   # Info include generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you
   # want to log everything, set the level to "debug".
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+  config.log_level = ENV.fetch("LOG_LEVEL", "info")
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
V configu sa nepouzival spravny nazov ENV premennej, mame nastaveny ENV `LOG_LEVEL`, nie `RAILS_LOG_LEVEL`.