### PR TITLE
Hot fix: slovensko.sk login

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -26,7 +26,7 @@ module Authentication
       session[:user_id] = Current.user.id
       session[:login_expires_at] = SESSION_TIMEOUT.from_now
       session[:tenant_id] = Current.user.tenant_id
-      session[:user_profile_picture_url] = user_avatar
+      session[:user_profile_picture_url] = auth_hash.info.image
       session[:box_id] = Current.user.tenant.boxes.first.id if Current.user.tenant.boxes.one?
       session[:upvs_login] = saml_identifier.present?
       redirect_to session[:after_login_path] || default_after_login_path


### PR DESCRIPTION
https://github.com/slovensko-digital/govbox-pro/pull/694 nam nejako nevedomky priniesol zvlastny bug, nefunguje odhlasenie pouzivatela, ktory je prihlaseny cez slovensko.sk.
Aktualne to sposobuje dost problemy, odhlasenie hadze 502 (aj napr. po vyprsani session na slovensko.sk, nedokoncene odhlasenie potom zabranuje opatovnemu prihlaseniu). Potrebujeme hotfix, nasledne doriesime ako tam dostat toho avatara bezpecne s5.
Toto je otestovane na stagingu, tento maly rollback odstranuje aktualny bug.