### PR TITLE
Fix notification badge flickering

### DIFF
--- a/app/components/t_w/user_menu_component.html.erb
+++ b/app/components/t_w/user_menu_component.html.erb
@@ -6,7 +6,11 @@
         </span>
 		    <div class="relative h-8 w-8">
 			    <img class="h-8 w-8 rounded-full bg-gray-50" alt="Avatar" src="<%= session[:user_profile_picture_url] %>">
-			    <%= render "notifications/badge", user: Current.user %>
+			    <div id="permanent_badge_wrapper" data-turbo-permanent>
+				    <turbo-frame id="notification_badge">
+					    <%= render "notifications/badge", user: Current.user %>
+				    </turbo-frame>
+			    </div>
 		    </div>
         <span class="hidden lg:flex lg:items-center">
           <svg class="ml-2 h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,7 +106,7 @@ class User < ApplicationRecord
   end
 
   def broadcast_badge_update
-    Turbo::StreamsChannel.broadcast_replace_to(
+    Turbo::StreamsChannel.broadcast_update_to(
       self,
       target: "notification_badge",
       partial: "notifications/badge",

--- a/app/views/notifications/_badge.html.erb
+++ b/app/views/notifications/_badge.html.erb
@@ -1,5 +1,3 @@
-<turbo-frame id="notification_badge">
-  <% unless user.notifications_opened? %>
-    <span class="absolute top-0 end-0 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-500 border-2 border-white" data-turbo></span>
-  <% end %>
-</turbo-frame>
+<% unless user.notifications_opened? %>
+	<span class="absolute top-0 end-0 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full bg-red-500 border-2 border-white"></span>
+<% end %>


### PR DESCRIPTION
Fix turbo stream and turbo permanent on notification badges to avoid flickering on navigation via Turbo + make sure turbo stream works correctly on notification badges