### PR TITLE
GO-311 Update changing feature_flags in admin

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -104,7 +104,7 @@ class Tenant < ApplicationRecord
   end
 
   def enable_feature(feature)
-    raise "Unknown feature #{feature}" unless feature.in? AVAILABLE_FEATURE_FLAGS
+    raise "Unknown feature #{feature}" unless feature.in? ALL_FEATURE_FLAGS
     raise "Feature already enabled" if feature.to_s.in? feature_flags
 
     feature_flags << feature
@@ -112,7 +112,7 @@ class Tenant < ApplicationRecord
   end
 
   def disable_feature(feature)
-    raise "Unknown feature #{feature}" unless feature.in? AVAILABLE_FEATURE_FLAGS
+    raise "Unknown feature #{feature}" unless feature.in? ALL_FEATURE_FLAGS
     raise "Feature not enabled" unless feature.to_s.in? feature_flags
 
     feature_flags.delete_if { |f| f == feature.to_s }


### PR DESCRIPTION
@jsuchal objavili sme, ze klienti si v adminovi vselijako (z nasho pohladu nezelane) nastavuju feature flagy. To dokaze spravit neporiadok, je to podla mna nezelane. Napr. nechtiac vypnutie fs syncu vie narobit zmatok, pripadne zapnutie moznosti API je bezucinne, pokial nema tenant nastavene kluce, atd, podobne archivacia.
Maximalne by som povolila zapnut/vypnut audit log, aj to je na zvazenie, ci to nedat cele prec.
