### PR TITLE
Mark message invalid if 1st validation job fails

### DIFF
--- a/app/jobs/fs/validate_message_draft_job.rb
+++ b/app/jobs/fs/validate_message_draft_job.rb
@@ -10,8 +10,18 @@ class Fs::ValidateMessageDraftJob < ApplicationJob
       Base64.strict_encode64(message_draft.form_object.content)
     )
 
-    raise RuntimeError.new("Response status is not 202. Message #{response[:body][:errors]}") unless response[:status] == 202
+    unless response[:status] == 202
+      mark_message_draft_invalid(message_draft)
+      raise RuntimeError.new("Response status is not 202. Message #{response[:body][:errors]}")
+    end
 
     Fs::ValidateMessageDraftStatusJob.perform_later(message_draft, response[:headers][:location])
+  end
+
+  private
+
+  def mark_message_draft_invalid(message_draft)
+    message_draft.metadata[:status] = 'invalid'
+    message_draft.add_cascading_tag(message_draft.tenant.submission_error_tag)
   end
 end

--- a/test/fixtures/message_object_data.yml
+++ b/test/fixtures/message_object_data.yml
@@ -27,3 +27,7 @@ ssd_main_draft_form_data:
 fs_one:
   message_object: ssd_main_fs_one_form
   blob: <n0:ElectronicOfficialDocument	xmlns:n0="http://schemas.gov.sk/form/42499500.FS_EUD_v1_0.sk/1.6">	<n0:Sender>		<n0:PersonData>			<n0:CorporateBody>				<n0:FinancialAdministrationAuthority>Daňový úrad Bratislava</n0:FinancialAdministrationAuthority>			</n0:CorporateBody>			<n0:PhysicalAddress>				<n0:AddressLine>Ševčenkova 32, 850 00  Bratislava</n0:AddressLine>			</n0:PhysicalAddress>		</n0:PersonData>	</n0:Sender>	<n0:Document>		<n0:DocumentReference>000000000/2022</n0:DocumentReference>		<n0:ContactPerson>Mgr. X Y</n0:ContactPerson>		<n0:PhoneNumber>02/00000000</n0:PhoneNumber>		<n0:EmailAddress>x.y@FINANCNASPRAVA.SK</n0:EmailAddress>		<n0:IssuePlace>Bratislava</n0:IssuePlace>		<n0:IssueDate>2022-04-19</n0:IssueDate>		<n0:Subject>Rozhodnutie</n0:Subject>	</n0:Document></n0:ElectronicOfficialDocument>
+
+fs_accountants_outbox_xml_form:
+  message_object: fs_accountants_outbox_xml_form
+  blob: <xml>1234</xml>

--- a/test/jobs/fs/validate_message_draft_job_test.rb
+++ b/test/jobs/fs/validate_message_draft_job_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class Fs::ValidateMessageDraftJobTest < ActiveJob::TestCase
+test "message is marked as invalid & FS API returns errors" do
+    outbox_message = messages(:fs_accountants_outbox)
+
+    fs_api = Minitest::Mock.new
+    fs_api.expect :post_validation, {
+      :status => 422,
+      :body => {
+      }
+    },
+    [ outbox_message.form.identifier, Base64.strict_encode64(outbox_message.form_object.content) ]
+
+    FsEnvironment.fs_client.stub :api, fs_api do
+      assert_raise do
+        subject.new.perform(outbox_message)
+
+        assert_equal outbox_message.metadata[:status] == 'invalid'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rovnakou logikou to mame riesene aj pri zvysnych joboch, len tu to chybalo. Aj ked tu to failuje malokedy, ale pre istotu, nech zachytime.