### PR TITLE
GO-322/fs-html-visualizations-indexing

### DIFF
--- a/app/models/searchable/index_helpers.rb
+++ b/app/models/searchable/index_helpers.rb
@@ -1,21 +1,13 @@
 module Searchable::IndexHelpers
   extend self
 
-  BODY_REGEXP = /<body[^>]*>(.*?)<\/body>/im
+  BODY_PATTERN = %r{<body[^>]*>(.*?)</body>}im
+  NON_SEARCHABLE_CSS = "head, script, style, noscript, template"
 
   def html_to_searchable_string(html)
     return html unless html
 
-    match = html.match(BODY_REGEXP)
-    body = match ? match[1] : html
-
-    create_single_line_string(
-      transliterate(
-        remove_html_tags(
-          add_spaces_between_tags(body)
-        )
-      )
-    )
+    searchable_string(extract_visible_text(html))
   end
 
   def searchable_string(string)
@@ -26,12 +18,13 @@ module Searchable::IndexHelpers
 
   private
 
-  def add_spaces_between_tags(html_string)
-    html_string.gsub(/<\/([^>]*)><([^>]*)>/, '</\1> <\2>')
-  end
+  def extract_visible_text(html)
+    source_html = html.to_s.scrub
+    source = source_html[BODY_PATTERN, 1] || source_html
 
-  def remove_html_tags(html)
-    ActionView::Base.full_sanitizer.sanitize(html)
+    fragment = Nokogiri::HTML4::DocumentFragment.parse(source)
+    fragment.css(NON_SEARCHABLE_CSS).remove
+    fragment.text
   end
 
   def create_single_line_string(string)

--- a/test/models/searchable/index_helpers_test.rb
+++ b/test/models/searchable/index_helpers_test.rb
@@ -6,4 +6,83 @@ class Searchable::IndexHelpersTest < ActiveSupport::TestCase
 
     assert_equal "text", Searchable::IndexHelpers.html_to_searchable_string(html)
   end
+
+  test "does not index head script and style when body is present" do
+    html = <<~HTML
+      <html>
+        <head>
+          <style>.hidden { display:none; }</style>
+          <script>var tokenFromHead = 'SHOULD_NOT_BE_INDEXED';</script>
+        </head>
+        <body>
+          Visible content only
+        </body>
+      </html>
+    HTML
+
+    result = Searchable::IndexHelpers.html_to_searchable_string(html)
+
+    assert_equal "Visible content only", result
+    assert_not_includes result, "SHOULD_NOT_BE_INDEXED"
+  end
+
+  test "does not index script and style text when body is missing" do
+    html = <<~HTML
+      <html>
+        <head>
+          <style>.hidden { display:none; }</style>
+          <script>var tokenFromScript = 'INDEXED_WHEN_BODY_MISSING';</script>
+        </head>
+        <div>Visible content only</div>
+      </html>
+    HTML
+
+    result = Searchable::IndexHelpers.html_to_searchable_string(html)
+
+    assert_not_includes result, "INDEXED_WHEN_BODY_MISSING"
+    assert_not_includes result, ".hidden"
+    assert_includes result, "Visible content only"
+  end
+
+  test "indexes namespaced body content without head script payload" do
+    html = <<~HTML
+      <html>
+        <head>
+          <script>var namespacedBodyToken = 'INDEXED_WITH_NAMESPACED_BODY';</script>
+        </head>
+        <xhtml:body>
+          Visible content only
+        </xhtml:body>
+      </html>
+    HTML
+
+    result = Searchable::IndexHelpers.html_to_searchable_string(html)
+
+    assert_not_includes result, "INDEXED_WITH_NAMESPACED_BODY"
+    assert_includes result, "Visible content only"
+  end
+
+  test "drops very large script payload when body is missing" do
+    html = "<html><script>#{large_script_payload}</script><div>visible text</div></html>"
+
+    result = Searchable::IndexHelpers.html_to_searchable_string(html)
+    legacy_result = ActionView::Base.full_sanitizer.sanitize(html).gsub(/\s+/, ' ').strip
+
+    assert_operator legacy_result.bytesize, :>, 1_000_000
+    assert_equal "visible text", result
+  end
+
+  test "drops very large head script payload when body is present" do
+    html = "<html><head><script>#{large_script_payload}</script></head><body>visible text</body></html>"
+
+    result = Searchable::IndexHelpers.html_to_searchable_string(html)
+
+    assert_equal "visible text", result
+  end
+
+  private
+
+  def large_script_payload
+    (1..130_000).map { |i| "tok#{i}" }.join(" ")
+  end
 end


### PR DESCRIPTION
Na prvy pohlad som nasiel, ze rizikove miesto dost pravdepodobne moze byt prevod HTML -> searchable text pri indexovani. Ak zlyha extrakcia body, mozu sa do indexu dostat aj script/style casti, co vie vyrazne nafuknut obsah a sposobit fail indexovania.                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
 Co mam overene:                                                                                                                                                                                
 - searchable testy presli                                                                                                                                                                      
 - synteticky scenar s velkym script payloadom uz po fixe nepada                                                                                                                                
                                                                                                                                                                                                
 Co este potrebujem, aby som si bol uplne isty:                                                                                                                                                 
 - otestovat to na realnych velkych FS HTML vizualizaciach 
 
 cc @luciajanikova 