### PR TITLE
GO-378 New tenant endpoints

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,0 +1,5 @@
+class Api::UsersController < Api::TenantController
+  def index
+    @users = @tenant.users.order(:id)
+  end
+end

--- a/app/views/api/boxes/index.json.jbuilder
+++ b/app/views/api/boxes/index.json.jbuilder
@@ -8,4 +8,9 @@ json.array! @boxes do |box|
   json.obo box.settings_obo if box.respond_to?(:settings_obo)
   json.dic box.settings_dic if box.respond_to?(:settings_dic)
   json.active box.active
+  json.api_connections box.api_connections do |api_connection|
+    json.id api_connection.id
+    json.custom_name api_connection.custom_name
+    json.owner_id api_connection.owner_id
+  end
 end

--- a/app/views/api/fs/api_connections/index.json.jbuilder
+++ b/app/views/api/fs/api_connections/index.json.jbuilder
@@ -1,6 +1,7 @@
 json.array! @api_connections do |api_connection|
   json.id api_connection.id
   json.custom_name api_connection.custom_name
+  json.owner_id api_connection.owner_id
   json.created_at api_connection.created_at
   json.updated_at api_connection.updated_at
 end

--- a/app/views/api/users/index.json.jbuilder
+++ b/app/views/api/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,7 @@ Rails.application.routes.draw do
       get :pdf
     end
 
+    resources :users, only: :index
     resources :boxes, only: :index
 
     namespace :fs do

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -226,6 +226,10 @@ paths:
                       description: Vlastný názov prepojenia
                       type: string
                       nullable: true
+                    owner_id:
+                      description: Identifikátor používateľa, ktorému prislúcha API prepojenie
+                      type: integer
+                      nullable: true
                     created_at:
                       description: Dátum a čas vytvorenia
                       type: string

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -112,6 +112,31 @@ paths:
       security:
         - "Tenant_Token": []
 
+  /api/users:
+    get:
+      tags: [Používatelia]
+      summary: Vráti zoznam používateľov tenanta
+      description: |
+        Vráti zoznam používateľov pre daného tenanta.
+      responses:
+        200:
+          description: Úspešné získanie zoznamu používateľov
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      description: Identifikátor používateľa v systéme GovBox Pro
+                      type: integer
+                    name:
+                      description: Meno používateľa
+                      type: string
+      security:
+        - "Tenant_Token": []
+
   /api/boxes:
     get:
       tags: [Schránky]

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -183,6 +183,23 @@ paths:
                     active:
                       description: Indikuje, či je možné schránku používať (napr. platná autorizácia na zastupovanie)
                       type: boolean
+                    api_connections:
+                        description: Zoznam API prepojení, cez ktoré je možné ku schránke pristupovať
+                        type: array
+                        items:
+                            type: object
+                            properties:
+                            id:
+                                description: Identifikátor API prepojenia v systéme GovBox Pro
+                                type: integer
+                            custom_name:
+                                description: Vlastný názov prepojenia, pokiaľ je nastavený
+                                type: string
+                                nullable: true
+                            owner_id:
+                                description: Identifikátor používateľa, ktorému prislúcha API prepojenie
+                                type: integer
+                                nullable: true
       security:
         - "Tenant_Token": []
 

--- a/test/fixtures/api_connections.yml
+++ b/test/fixtures/api_connections.yml
@@ -171,6 +171,7 @@ fs_api_connection3:
 
 fs_api_connection4:
   sub: fs_sub4
+  custom_name: 'FS account 4'
   type: 'Fs::ApiConnection'
   tenant: accountants
   settings: {"username": "123456789", "password": "fs_password1"}
@@ -207,6 +208,7 @@ fs_api_connection4:
 
 fs_api_connection5:
   sub: fs_sub5
+  custom_name: 'FS account 5'
   type: 'Fs::ApiConnection'
   tenant: accountants
   settings: {"username": "123456789", "password": "fs_password1"}
@@ -243,6 +245,7 @@ fs_api_connection5:
 
 fs_api_connection6:
   sub: fs_sub6
+  custom_name: 'FS account 6'
   type: 'Fs::ApiConnection'
   tenant: accountants
   settings: {"username": "123456789", "password": "fs_password1"}

--- a/test/integration/boxes_api_test.rb
+++ b/test/integration/boxes_api_test.rb
@@ -54,6 +54,28 @@ class BoxesApiTest < ActionDispatch::IntegrationTest
     assert_equal fs_box.settings_dic, fs_box_json["dic"]
   end
 
+  test "includes boxes API connections" do
+    tenant = tenants(:accountants)
+
+    get "/api/boxes", params: { token: generate_api_token(sub: tenant.id, key_pair: @key_pair) }, as: :json
+
+    assert_response :success
+    json_response = JSON.parse(response.body)
+
+    fs_box = boxes(:fs_accountants)
+    fs_box_json = json_response.find { |box| box["id"] == fs_box.id }
+    assert fs_box_json
+    assert_equal fs_box.settings_dic, fs_box_json["dic"]
+    assert_equal fs_box.settings_dic, fs_box_json["dic"]
+
+    fs_box_multiple_connections = boxes(:fs_accountants_multiple_api_connections)
+    fs_box_multiple_connections_json = json_response.find { |box| box["id"] == fs_box_multiple_connections.id }
+
+    assert_equal 3, fs_box_multiple_connections_json["api_connections"].count
+    assert_equal ["FS account 4", "FS account 5", "FS account 6"].to_set, fs_box_multiple_connections_json["api_connections"].pluck("custom_name").to_set
+
+  end
+
   test "includes active flag for boxes" do
     tenant = tenants(:accountants)
     inactive_box = boxes(:fs_accountants)

--- a/test/integration/users_api_test.rb
+++ b/test/integration/users_api_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class UsersApiTest < ActionDispatch::IntegrationTest
+  setup do
+    @key_pair = OpenSSL::PKey::RSA.new File.read 'test/fixtures/tenant_test_cert.pem'
+  end
+
+  test "lists users for tenant" do
+    tenant = tenants(:ssd)
+
+    get "/api/users", params: { token: generate_api_token(sub: tenant.id, key_pair: @key_pair) }, as: :json
+
+    assert_response :success
+    json_response = JSON.parse(response.body)
+
+    assert_equal tenant.users.order(:id).pluck(:id), json_response.pluck("id")
+    assert_equal ["Basic user", "Another user", "Signer user", "Signer user 2", "Admin user", "Notification user"].to_set, json_response.pluck("name").to_set
+  end
+end


### PR DESCRIPTION
Riesenie pre scenar, kedy pri nahravani FS draftu rovno chce zadavatel requestu vyziadat podpis, kto chce, aby podanie podpisal. K tomu vsak potrebuje poznat informacie, ktore API connections sa viazu na danu schranku a ktori pouzivatelia su vlastnikmi danych API connections.