### PR TITLE
Do not retry GovBox::ProcessMessageJob on StandardError

### DIFF
--- a/app/jobs/govbox/process_message_job.rb
+++ b/app/jobs/govbox/process_message_job.rb
@@ -3,6 +3,7 @@ require 'json'
 module Govbox
   class ProcessMessageJob < ApplicationJob
     retry_on ::ApplicationRecord::FailedToAcquireLockError, wait: :polynomially_longer, attempts: Float::INFINITY
+    retry_on StandardError, attempts: 1
 
     def perform(govbox_message)
       processed_message = ::Message.not_drafts.where(uuid: govbox_message.message_id).joins(:thread).where(thread: { box_id: govbox_message.box.id }).take


### PR DESCRIPTION
Nechceme, aby sa `GovBox::ProcessMessageJob` opakoval, ak tam nieco failne. To znamena, ze sa spravy zo schranky nedostane do GO, kriticka vec. Chceme, aby job vyfailoval a boli sme na to upozorneni, ze sa tam nieco take udialo, riesili.