### PR TITLE
Fallback to trial registration redirect on no account

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -29,7 +29,9 @@ module Authentication
       session[:upvs_login] = saml_identifier.present?
       redirect_to session[:after_login_path] || default_after_login_path
     else
-      redirect_to no_account_sessions_path(saml_identifier: saml_identifier, username: username)
+      session[:saml_identifier] = saml_identifier
+      session[:username] = username
+      redirect_to no_account_sessions_path
     end
   end
 

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -19,7 +19,7 @@ module Authentication
     load_current_user
   end
 
-  def create_session(saml_identifier: nil)
+  def create_session(saml_identifier: nil, username: nil)
     if Current.user
       session[:user_id] = Current.user.id
       session[:login_expires_at] = SESSION_TIMEOUT.from_now
@@ -29,7 +29,7 @@ module Authentication
       session[:upvs_login] = saml_identifier.present?
       redirect_to session[:after_login_path] || default_after_login_path
     else
-      redirect_to no_account_sessions_path(saml_identifier: saml_identifier)
+      redirect_to no_account_sessions_path(saml_identifier: saml_identifier, username: username)
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,10 +14,6 @@ class SessionsController < ApplicationController
     return unless params[:ssd_trial].present? && valid_return_url?(params[:return_url])
 
     session[:ssd_trial_return_url] = params[:return_url]
-    @ssd_trial_relay_state = Rails.application.message_verifier(:ssd_trial_return_url).generate(
-      params[:return_url],
-      expires_in: 15.minutes
-    )
   end
 
   def create

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -38,12 +38,12 @@ class SessionsController < ApplicationController
   end
 
   def no_account_trial
-    return redirect_to no_account_sessions_path(saml_identifier: params[:saml_identifier], username: params[:username]) unless no_account_trial_enabled?
+    return redirect_to no_account_sessions_path unless no_account_trial_enabled?
 
-    saml_identifier = params[:saml_identifier]
-    username = params[:username]
+    saml_identifier = session[:saml_identifier]
+    username = session[:username]
 
-    return redirect_to no_account_sessions_path(saml_identifier: saml_identifier, username: username) if saml_identifier.blank? || username.blank?
+    return redirect_to no_account_sessions_path if saml_identifier.blank? || username.blank?
 
     token = JWT.encode(
       {

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,14 +4,16 @@ class SessionsController < ApplicationController
   skip_before_action :set_menu_context
   layout 'login'
 
-  ALLOWED_RETURN_URLS = ENV.fetch('SSD_TRIAL_RETURN_URL_ALLOWLIST', '').split(",")
-
   def login; end
 
   def trial_login
     return unless params[:ssd_trial].present? && valid_return_url?(params[:return_url])
 
     session[:ssd_trial_return_url] = params[:return_url]
+    @ssd_trial_relay_state = Rails.application.message_verifier(:ssd_trial_return_url).generate(
+      params[:return_url],
+      expires_in: 15.minutes
+    )
   end
 
   def create
@@ -43,8 +45,12 @@ class SessionsController < ApplicationController
     uri = URI.parse(url.to_s)
     return true if uri.host.nil? && uri.scheme.nil?
 
-    %w[http https].include?(uri.scheme) && ALLOWED_RETURN_URLS.include?(url)
+    %w[http https].include?(uri.scheme) && allowed_return_urls.include?(url)
   rescue URI::InvalidURIError
     false
+  end
+
+  def allowed_return_urls
+    ENV.fetch('SSD_TRIAL_RETURN_URL_ALLOWLIST', '').split(',')
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,6 +6,10 @@ class SessionsController < ApplicationController
 
   def login; end
 
+  def no_account
+    @no_account_trial_enabled = no_account_trial_enabled?
+  end
+
   def trial_login
     return unless params[:ssd_trial].present? && valid_return_url?(params[:return_url])
 
@@ -37,7 +41,39 @@ class SessionsController < ApplicationController
     render html: "Authorization failed (#{request.params["message"]})", status: :forbidden
   end
 
+  def no_account_trial
+    return redirect_to no_account_sessions_path(saml_identifier: params[:saml_identifier], username: params[:username]) unless no_account_trial_enabled?
+
+    saml_identifier = params[:saml_identifier]
+    username = params[:username]
+
+    return redirect_to no_account_sessions_path(saml_identifier: saml_identifier, username: username) if saml_identifier.blank? || username.blank?
+
+    token = JWT.encode(
+      {
+        saml_identifier: saml_identifier,
+        username: username,
+        exp: 5.minutes.from_now.to_i
+      },
+      ENV.fetch('SSD_TRIAL_SHARED_SECRET'),
+      'HS256'
+    )
+
+    uri = URI.parse(no_account_trial_return_url)
+    uri.query = URI.encode_www_form(URI.decode_www_form(uri.query.to_s).append(['token', token]))
+
+    redirect_to uri.to_s, allow_other_host: true
+  end
+
   private
+
+  def no_account_trial_enabled?
+    no_account_trial_return_url.present? && ENV.fetch('SSD_TRIAL_SHARED_SECRET', '').present?
+  end
+
+  def no_account_trial_return_url
+    ENV.fetch('SSD_NO_ACCOUNT_TRIAL_RETURN_URL', '').presence
+  end
 
   def valid_return_url?(url)
     return false if url.blank?

--- a/app/controllers/upvs_controller.rb
+++ b/app/controllers/upvs_controller.rb
@@ -12,9 +12,9 @@ class UpvsController < ActionController::API
     username = response.attributes["Actor.FormattedName"]
 
     Current.user = User.find_by(saml_identifier: saml_identifier)
-    return_url = session.delete(:ssd_trial_return_url).presence || relay_state_trial_return_url
 
     if Current.user.nil? && return_url.present?
+      return_url = session.delete(:ssd_trial_return_url)
       token = JWT.encode(
         {
           saml_identifier: saml_identifier,
@@ -55,31 +55,6 @@ class UpvsController < ActionController::API
   end
 
   private
-
-  def relay_state_trial_return_url
-    relay_state = params[:RelayState].presence
-    return if relay_state.blank?
-
-    return_url = Rails.application.message_verifier(:ssd_trial_return_url).verify(relay_state)
-    valid_return_url?(return_url) ? return_url : nil
-  rescue ActiveSupport::MessageVerifier::InvalidSignature
-    nil
-  end
-
-  def valid_return_url?(url)
-    return false if url.blank?
-
-    uri = URI.parse(url.to_s)
-    return true if uri.host.nil? && uri.scheme.nil?
-
-    %w[http https].include?(uri.scheme) && allowed_return_urls.include?(url)
-  rescue URI::InvalidURIError
-    false
-  end
-
-  def allowed_return_urls
-    ENV.fetch('SSD_TRIAL_RETURN_URL_ALLOWLIST', '').split(',')
-  end
 
   def slo_request_params
     params.permit(:SAMLRequest, :SigAlg, :Signature)

--- a/app/controllers/upvs_controller.rb
+++ b/app/controllers/upvs_controller.rb
@@ -13,7 +13,7 @@ class UpvsController < ActionController::API
 
     Current.user = User.find_by(saml_identifier: saml_identifier)
 
-    if Current.user.nil? && return_url.present?
+    if Current.user.nil? && session[:ssd_trial_return_url].present?
       return_url = session.delete(:ssd_trial_return_url)
       token = JWT.encode(
         {

--- a/app/controllers/upvs_controller.rb
+++ b/app/controllers/upvs_controller.rb
@@ -36,7 +36,7 @@ class UpvsController < ActionController::API
 
     session.delete(:ssd_trial_return_url)
 
-    create_session(saml_identifier: saml_identifier)
+    create_session(saml_identifier: saml_identifier, username: username)
     EventBus.publish(:user_logged_in, Current.user) if Current.user
   end
 

--- a/app/controllers/upvs_controller.rb
+++ b/app/controllers/upvs_controller.rb
@@ -12,10 +12,9 @@ class UpvsController < ActionController::API
     username = response.attributes["Actor.FormattedName"]
 
     Current.user = User.find_by(saml_identifier: saml_identifier)
+    return_url = session.delete(:ssd_trial_return_url).presence || relay_state_trial_return_url
 
-    if Current.user.nil? && session[:ssd_trial_return_url].present?
-      return_url = session.delete(:ssd_trial_return_url)
-
+    if Current.user.nil? && return_url.present?
       token = JWT.encode(
         {
           saml_identifier: saml_identifier,
@@ -32,7 +31,7 @@ class UpvsController < ActionController::API
         URI.decode_www_form(uri.query.to_s).append(["token", token])
       )
 
-      return redirect_to(uri.to_s)
+      return redirect_to(uri.to_s, allow_other_host: true)
     end
 
     session.delete(:ssd_trial_return_url)
@@ -56,6 +55,31 @@ class UpvsController < ActionController::API
   end
 
   private
+
+  def relay_state_trial_return_url
+    relay_state = params[:RelayState].presence
+    return if relay_state.blank?
+
+    return_url = Rails.application.message_verifier(:ssd_trial_return_url).verify(relay_state)
+    valid_return_url?(return_url) ? return_url : nil
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    nil
+  end
+
+  def valid_return_url?(url)
+    return false if url.blank?
+
+    uri = URI.parse(url.to_s)
+    return true if uri.host.nil? && uri.scheme.nil?
+
+    %w[http https].include?(uri.scheme) && allowed_return_urls.include?(url)
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def allowed_return_urls
+    ENV.fetch('SSD_TRIAL_RETURN_URL_ALLOWLIST', '').split(',')
+  end
 
   def slo_request_params
     params.permit(:SAMLRequest, :SigAlg, :Signature)

--- a/app/views/sessions/no_account.html.erb
+++ b/app/views/sessions/no_account.html.erb
@@ -1,21 +1,22 @@
 <div class="flex min-h-full flex-col justify-center py-12 sm:px-6 lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-md">
     <%= image_tag("SD_icon.png", alt: "logo", class: "mx-auto h-10 w-auto") %>
-    <h2 class="mt-6 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Nemáte vytvorený účet</h2>
+    <h2 class="mt-6 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Ešte nemáte vytvorený účet</h2>
   </div>
   <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-[480px]">
     <div class="bg-white px-6 py-12 shadow sm:rounded-lg sm:px-12">
-      <p class="text-center text-gray-900">
-        <a href="#" class="font-semibold leading-6 text-indigo-600 hover:text-indigo-500">Kontaktujte nás</a> s požiadavkou o vytvorenie účtu
-        <%= (" spolu s Vašim identifikátorom: " + params[:saml_identifier]) if params[:saml_identifier] %>
-      </p>
-
       <% if @no_account_trial_enabled %>
+        <p class="text-center text-gray-900">Pokračujte kliknutím na tlačidlo nižšie a získate bezplatný 30-dňový účet GovBox PRO.</p>
         <div class="mt-8">
           <%= button_to no_account_trial_sessions_path, method: :post, params: { saml_identifier: params[:saml_identifier], username: params[:username] }, class: "flex w-full items-center justify-center gap-3 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2" do %>
             <span class="text-sm font-semibold leading-6">Vytvoriť bezplatný 30-dňový účet</span>
           <% end %>
         </div>
+      <% else %>
+        <p class="text-center text-gray-900">
+          <a href="#" class="font-semibold leading-6 text-indigo-600 hover:text-indigo-500">Kontaktujte nás</a> s požiadavkou o vytvorenie účtu
+          <%= (" spolu s Vašim identifikátorom: " + params[:saml_identifier]) if params[:saml_identifier] %>
+        </p>
       <% end %>
     </div>
   </div>

--- a/app/views/sessions/no_account.html.erb
+++ b/app/views/sessions/no_account.html.erb
@@ -9,6 +9,14 @@
         <a href="#" class="font-semibold leading-6 text-indigo-600 hover:text-indigo-500">Kontaktujte nás</a> s požiadavkou o vytvorenie účtu
         <%= (" spolu s Vašim identifikátorom: " + params[:saml_identifier]) if params[:saml_identifier] %>
       </p>
+
+      <% if @no_account_trial_enabled %>
+        <div class="mt-8">
+          <%= button_to no_account_trial_sessions_path, method: :post, params: { saml_identifier: params[:saml_identifier], username: params[:username] }, class: "flex w-full items-center justify-center gap-3 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2" do %>
+            <span class="text-sm font-semibold leading-6">Vytvoriť bezplatný 30-dňový účet</span>
+          <% end %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/sessions/no_account.html.erb
+++ b/app/views/sessions/no_account.html.erb
@@ -9,7 +9,7 @@
         <p class="text-center text-gray-900">Pokračujte kliknutím na tlačidlo nižšie a získate bezplatný 30-dňový účet GovBox PRO.</p>
         <div class="mt-8">
           <%= button_to no_account_trial_sessions_path, method: :post, params: { saml_identifier: params[:saml_identifier], username: params[:username] }, class: "flex w-full items-center justify-center gap-3 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2" do %>
-            <span class="text-sm font-semibold leading-6">Vytvoriť bezplatný 30-dňový účet</span>
+            <span class="text-sm font-semibold leading-6">Pokračovať na registráciu</span>
           <% end %>
         </div>
       <% else %>

--- a/app/views/sessions/no_account.html.erb
+++ b/app/views/sessions/no_account.html.erb
@@ -8,14 +8,14 @@
       <% if @no_account_trial_enabled %>
         <p class="text-center text-gray-900">Pokračujte kliknutím na tlačidlo nižšie a získate bezplatný 30-dňový účet GovBox PRO.</p>
         <div class="mt-8">
-          <%= button_to no_account_trial_sessions_path, method: :post, params: { saml_identifier: params[:saml_identifier], username: params[:username] }, class: "flex w-full items-center justify-center gap-3 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2" do %>
+          <%= button_to no_account_trial_sessions_path, method: :post, class: "flex w-full items-center justify-center gap-3 rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:ring-2 focus-visible:ring-indigo-600 focus-visible:ring-offset-2" do %>
             <span class="text-sm font-semibold leading-6">Pokračovať na registráciu</span>
           <% end %>
         </div>
       <% else %>
         <p class="text-center text-gray-900">
           <a href="#" class="font-semibold leading-6 text-indigo-600 hover:text-indigo-500">Kontaktujte nás</a> s požiadavkou o vytvorenie účtu
-          <%= (" spolu s Vašim identifikátorom: " + params[:saml_identifier]) if params[:saml_identifier] %>
+          <%= (" spolu s Vašim identifikátorom: " + session[:saml_identifier]) if session[:saml_identifier] %>
         </p>
       <% end %>
     </div>

--- a/app/views/sessions/trial_login.html.erb
+++ b/app/views/sessions/trial_login.html.erb
@@ -29,7 +29,7 @@
       </div>
       <div class="grid grid-cols-1 gap-6">
         <% if UpvsEnvironment.sso_support? %>
-          <%= button_to "/auth/saml", method: :post, data: { turbo: false }, class: "flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus-visible:ring-transparent" do %>
+          <%= button_to "/auth/saml", method: :post, params: (@ssd_trial_relay_state.present? ? { RelayState: @ssd_trial_relay_state } : {}), data: { turbo: false }, class: "flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus-visible:ring-transparent" do %>
             <svg class="h-5 w-5 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
             </svg>

--- a/app/views/sessions/trial_login.html.erb
+++ b/app/views/sessions/trial_login.html.erb
@@ -29,7 +29,7 @@
       </div>
       <div class="grid grid-cols-1 gap-6">
         <% if UpvsEnvironment.sso_support? %>
-          <%= button_to "/auth/saml", method: :post, params: (@ssd_trial_relay_state.present? ? { RelayState: @ssd_trial_relay_state } : {}), data: { turbo: false }, class: "flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus-visible:ring-transparent" do %>
+          <%= button_to "/auth/saml", method: :post, data: { turbo: false }, class: "flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus-visible:ring-transparent" do %>
             <svg class="h-5 w-5 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
             </svg>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -224,6 +224,7 @@ Rails.application.routes.draw do
   resources :sessions do
     get :login, on: :collection
     get :no_account, on: :collection
+    get :no_account_trial, on: :collection
     delete :destroy, on: :collection
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -224,7 +224,7 @@ Rails.application.routes.draw do
   resources :sessions do
     get :login, on: :collection
     get :no_account, on: :collection
-    get :no_account_trial, on: :collection
+    post :no_account_trial, on: :collection
     delete :destroy, on: :collection
   end
 


### PR DESCRIPTION
Tá session nám nejako nepretrvá medzi /trial/prihlasenie a potom /callback z upvs. `ssd_trial_return_url` tam nie je uložená, keď sa spracúva ten callback. Preto som to upravil takto, že aj keď sa dostaneš na default no_account stránku, tak tam dostaneš talčidlo, ktoré ťa pošle na tú registráciu aj bez toho, aby si niekde mala uloženú return_url - default bude tá na ten ssd web.

Jedna vec sa mi tu nepáči, že na tú no_account stránku posielam saml identifier a username iba v query parametroch, takže tam vie prípadný útočník poslať aj nejaké nie svoje. Toto by sa ešte dalo, že tento jwt token vyrobíme už rovno v callback akcii a budeme ďalej do redirectov posielať ten token rovno oditaľ.