### PR TITLE
Add FS API connection setup flow with homepage notification

### DIFF
--- a/app/controllers/admin/api_connections/fs_api_connections_controller.rb
+++ b/app/controllers/admin/api_connections/fs_api_connections_controller.rb
@@ -1,4 +1,16 @@
 class Admin::ApiConnections::FsApiConnectionsController < Admin::ApiConnectionsController
+  def init
+    authorize([:admin, @api_connection])
+
+    return unless request.patch?
+
+    if @api_connection.update(api_connection_params)
+      boxify_and_redirect_from_init
+    else
+      render :init, status: :unprocessable_content
+    end
+  end
+
   def update
     authorize([:admin, @api_connection])
     if @api_connection.update(api_connection_params)
@@ -20,6 +32,15 @@ class Admin::ApiConnections::FsApiConnectionsController < Admin::ApiConnectionsC
   end
 
   private
+
+  def boxify_and_redirect_from_init
+    count = @api_connection.boxify
+    redirect_to message_threads_path,
+                notice: "Prepojenie s FS bolo úspešne nastavené. Vytvorených schránok: #{count}"
+  rescue StandardError
+    redirect_to init_admin_tenant_api_connections_fs_api_connection_path(Current.tenant, @api_connection),
+                alert: "Prepojenie bolo uložené, ale schránky sa nepodarilo vytvoriť. Skúste uloženie zopakovať."
+  end
 
   def api_connection_params
     params.require(:fs_api_connection).permit(:custom_name, :settings_username, :settings_password).compact_blank!

--- a/app/controllers/message_threads_controller.rb
+++ b/app/controllers/message_threads_controller.rb
@@ -6,6 +6,7 @@ class MessageThreadsController < ApplicationController
   before_action :set_thread_tags, only: %i[show history]
   before_action :set_thread_messages, only: %i[show history confirm_unarchive archive]
   before_action :load_threads, only: %i[index scroll]
+  before_action :set_unconfigured_fs_api_connections, only: :index
   before_action :set_subscription, only: :index
   before_action :set_reload
 
@@ -110,6 +111,12 @@ class MessageThreadsController < ApplicationController
   end
 
   private
+
+  def set_unconfigured_fs_api_connections
+    @unconfigured_fs_api_connections = Current.tenant.api_connections.where(type: "Fs::ApiConnection").select do |api_connection|
+      !api_connection.credentials_configured? && policy([:admin, api_connection]).init?
+    end
+  end
 
   def set_subscription
     return unless params[:q]

--- a/app/models/fs/api_connection.rb
+++ b/app/models/fs/api_connection.rb
@@ -49,6 +49,10 @@ class Fs::ApiConnection < ::ApiConnection
     false
   end
 
+  def credentials_configured?
+    settings_username.present? && settings_password.present?
+  end
+
   def boxify
     count = 0
     fs_api = FsEnvironment.fs_client.api(api_connection: self)

--- a/app/policies/admin/fs/api_connection_policy.rb
+++ b/app/policies/admin/fs/api_connection_policy.rb
@@ -1,4 +1,8 @@
 class Admin::Fs::ApiConnectionPolicy < Admin::ApiConnectionPolicy
+  def init?
+    update?
+  end
+
   def boxify?
     true
   end

--- a/app/views/admin/api_connections/fs_api_connections/_form.html.erb
+++ b/app/views/admin/api_connections/fs_api_connections/_form.html.erb
@@ -1,3 +1,9 @@
+<% title = local_assigns.fetch(:title) { @api_connection.new_record? ? 'Nové prepojenie s FS' : 'Úprava prepojenia s FS' } %>
+<% form_url = local_assigns.fetch(:url) { polymorphic_path([:admin, Current.tenant, :api_connections, @api_connection]) } %>
+<% submit_label = local_assigns.fetch(:submit_label) { @api_connection.new_record? ? 'Vytvoriť' : 'Uložiť' } %>
+<% form_method = local_assigns[:method] %>
+<% show_discard_button = local_assigns.fetch(:show_discard_button, true) %>
+
 <%= tag.turbo_frame id: "modal" do %>
   <div class="fixed inset-0 z-40 p-2" role="dialog" aria-modal="true">
     <div class="fixed inset-0 transition-opacity bg-gray-400 bg-opacity-75" aria-hidden="true"></div>
@@ -5,11 +11,11 @@
       <div class="flex flex-col justify-start items-start overflow-hidden rounded-lg bg-white border border-gray-300" style="box-shadow: 1px 1px 4px 0 rgba(0,0,0,0.1);">
         <div class="flex justify-start items-center self-stretch flex-grow-0 flex-shrink-0 overflow-hidden gap-4 px-6 py-4 border-t-0 border-r-0 border-b border-l-0 border-gray-200">
           <div class="flex flex-col justify-start items-start flex-grow relative">
-            <p class="self-stretch flex-grow-0 flex-shrink-0 text-xl font-semibold text-left text-gray-900"><%= @api_connection.new_record? ? 'Nové prepojenie s FS' : 'Úprava prepojenia s FS'%></p>
+            <p class="self-stretch flex-grow-0 flex-shrink-0 text-xl font-semibold text-left text-gray-900"><%= title %></p>
           </div>
           <%= render Common::CloseButtonComponent.new(link_to: admin_tenant_api_connections_path(Current.tenant)) %>
         </div>
-        <%= form_with model: [:admin, Current.tenant, @api_connection], scope: :fs_api_connection, url: polymorphic_path([:admin, Current.tenant, :api_connections, @api_connection]) do |form| %>
+        <%= form_with model: [:admin, Current.tenant, @api_connection], scope: :fs_api_connection, url: form_url, method: form_method do |form| %>
           <%= form.hidden_field(:type, value: 'Fs::ApiConnection') %>
           <div class="w-96">
             <div class="px-6 py-4">
@@ -44,11 +50,13 @@
             </div>
           </div>
           <div class="flex justify-start items-start self-stretch flex-grow-0 flex-shrink-0 gap-2 p-6">
-            <%= link_to admin_tenant_api_connections_path(Current.tenant), class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md bg-white border border-gray-300", data: { turbo_frame: "_top" } do %>
-              <p class="flex-grow-0 flex-shrink-0 text-base font-medium text-left text-gray-900">Zahodiť</p>
+            <% if show_discard_button %>
+              <%= link_to admin_tenant_api_connections_path(Current.tenant), class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md bg-white border border-gray-300", data: { turbo_frame: "_top" } do %>
+                <p class="flex-grow-0 flex-shrink-0 text-base font-medium text-left text-gray-900">Zahodiť</p>
+              <% end %>
             <% end %>
             <%= form.button class: "flex justify-center items-center flex-grow relative overflow-hidden gap-2.5 px-3.5 py-2.5 rounded-md bg-blue-600", data: { turbo_frame: "_top" } do %>
-              <p class="flex-grow-0 flex-shrink-0 text-base font-medium text-left text-white"><%= @api_connection.new_record? ? 'Vytvoriť' : 'Uložiť' %></p>
+              <p class="flex-grow-0 flex-shrink-0 text-base font-medium text-left text-white"><%= submit_label %></p>
             <% end %>
           </div>
         <% end %>

--- a/app/views/admin/api_connections/fs_api_connections/init.html.erb
+++ b/app/views/admin/api_connections/fs_api_connections/init.html.erb
@@ -1,0 +1,6 @@
+<%= render "form",
+           title: "Konfigurácia prepojenia s FS",
+           url: init_admin_tenant_api_connections_fs_api_connection_path(Current.tenant, @api_connection),
+           method: :patch,
+           submit_label: "Uložiť",
+           show_discard_button: false %>

--- a/app/views/message_threads/_fs_api_connection_setup_notice.html.erb
+++ b/app/views/message_threads/_fs_api_connection_setup_notice.html.erb
@@ -1,6 +1,6 @@
 <% if api_connections.present? %>
   <div class="mx-4 my-4 rounded-md border border-yellow-300 bg-yellow-50 p-4 text-sm text-yellow-900">
-    <p class="font-semibold">Nastavte prepojenie s finančnou správou</p>
+    <p class="font-semibold">Nastavte prihlasovacie údaje pre finančnú správu</p>
     <p class="mt-1">Pre používanie správ z finančnej správy je potrebné doplniť prihlasovacie údaje k FS API prepojeniu.</p>
     <ul class="mt-3 list-disc space-y-1 pl-5">
       <% api_connections.each do |api_connection| %>

--- a/app/views/message_threads/_fs_api_connection_setup_notice.html.erb
+++ b/app/views/message_threads/_fs_api_connection_setup_notice.html.erb
@@ -1,0 +1,16 @@
+<% if api_connections.present? %>
+  <div class="mx-4 my-4 rounded-md border border-yellow-300 bg-yellow-50 p-4 text-sm text-yellow-900">
+    <p class="font-semibold">Nastavte prepojenie s finančnou správou</p>
+    <p class="mt-1">Pre používanie správ z finančnej správy je potrebné doplniť prihlasovacie údaje k FS API prepojeniu.</p>
+    <ul class="mt-3 list-disc space-y-1 pl-5">
+      <% api_connections.each do |api_connection| %>
+        <li>
+          <%= link_to "Nastaviť prepojenie #{api_connection.name}",
+                      init_admin_tenant_api_connections_fs_api_connection_path(Current.tenant, api_connection),
+                      class: "font-semibold underline",
+                      data: { turbo_frame: "modal" } %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/message_threads/index.html.erb
+++ b/app/views/message_threads/index.html.erb
@@ -6,6 +6,8 @@
 
 <%= render partial: "sticky_notes/sticky_note" %>
 
+<%= render partial: "fs_api_connection_setup_notice", locals: { api_connections: @unconfigured_fs_api_connections } %>
+
 <%= render MessageThreadsTableComponent.new(filter: @filter, filter_subscription: @filter_subscription, count_estimate: @count_estimate) do |component| %>
   <% if @message_threads.any? %>
     <% component.with_message_thread do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,11 @@ Rails.application.routes.draw do
       namespace :api_connections do
         resources :upvs_api_connections, except: [:index, :destroy]
         resources :fs_api_connections, except: [:index, :destroy] do
-          post :boxify, on: :member
+          member do
+            get :init
+            patch :init
+            post :boxify
+          end
         end
       end
 

--- a/test/controllers/admin/api_connections/fs_api_connections_controller_test.rb
+++ b/test/controllers/admin/api_connections/fs_api_connections_controller_test.rb
@@ -1,0 +1,112 @@
+require "test_helper"
+
+class Admin::ApiConnections::FsApiConnectionsControllerTest < ActionController::TestCase
+  setup do
+    @controller = Admin::ApiConnections::FsApiConnectionsController.new
+    @tenant = tenants(:accountants)
+    @admin = users(:accountants_basic)
+    @api_connection = api_connections(:fs_api_connection1)
+
+    Current.tenant = @tenant
+    Current.user = @admin
+    session[:tenant_id] = @tenant.id
+    session[:user_id] = @admin.id
+    session[:login_expires_at] = Time.current + 1.day
+  end
+
+  teardown do
+    Current.reset
+  end
+
+  test "init renders setup form" do
+    get :init, params: { tenant_id: @tenant.id, id: @api_connection.id }
+
+    assert_response :success
+    assert_includes @response.body, "Konfigurácia prepojenia s FS"
+    assert_not_includes @response.body, "Úprava prepojenia s FS"
+    assert_not_includes @response.body, "Zahodiť"
+    assert_includes @response.body, init_admin_tenant_api_connections_fs_api_connection_path(@tenant, @api_connection)
+    assert_includes @response.body, "Prihlasovacie meno na portál FS"
+    assert_includes @response.body, "Heslo na portál FS"
+  end
+
+  test "init save updates connection and boxifies" do
+    fs_api = Minitest::Mock.new
+    fs_api.expect :get_subjects, []
+
+    FsEnvironment.fs_client.stub :api, fs_api do
+      patch :init, params: {
+        tenant_id: @tenant.id,
+        id: @api_connection.id,
+        fs_api_connection: {
+          custom_name: "Setup FS",
+          settings_username: "new-login",
+          settings_password: "new-password"
+        }
+      }
+    end
+
+    assert_redirected_to message_threads_path
+    assert_equal "Prepojenie s FS bolo úspešne nastavené. Vytvorených schránok: 0", flash[:notice]
+
+    @api_connection.reload
+    assert_equal "Setup FS", @api_connection.custom_name
+    assert_equal "new-login", @api_connection.settings_username
+    assert_equal "new-password", @api_connection.settings_password
+    fs_api.verify
+  end
+
+  test "init save does not boxify when update fails" do
+    Fs::ApiConnection.class_eval do
+      alias_method :update_without_test_failure, :update
+      alias_method :boxify_without_test_failure, :boxify
+
+      def update(*)
+        false
+      end
+
+      def boxify
+        raise "boxify must not be called"
+      end
+    end
+
+    patch :init, params: {
+      tenant_id: @tenant.id,
+      id: @api_connection.id,
+      fs_api_connection: {
+        settings_username: "not-saved",
+        settings_password: "not-saved"
+      }
+    }
+
+    assert_response :unprocessable_content
+  ensure
+    Fs::ApiConnection.class_eval do
+      alias_method :update, :update_without_test_failure
+      alias_method :boxify, :boxify_without_test_failure
+      remove_method :update_without_test_failure
+      remove_method :boxify_without_test_failure
+    end
+  end
+
+  test "init save keeps credentials and shows safe alert when boxify fails" do
+    FsEnvironment.fs_client.stub :api, ->(*) { raise StandardError, "sensitive internal error" } do
+      patch :init, params: {
+        tenant_id: @tenant.id,
+        id: @api_connection.id,
+        fs_api_connection: {
+          settings_username: "saved-login",
+          settings_password: "saved-password"
+        }
+      }
+    end
+
+    assert_redirected_to init_admin_tenant_api_connections_fs_api_connection_path(@tenant, @api_connection)
+    assert_includes flash[:alert], "Prepojenie bolo uložené"
+    assert_not_includes flash[:alert], "sensitive internal error"
+
+    @api_connection.reload
+    assert_equal "saved-login", @api_connection.settings_username
+    assert_equal "saved-password", @api_connection.settings_password
+  end
+end

--- a/test/controllers/message_threads/fs_api_connection_setup_notice_test.rb
+++ b/test/controllers/message_threads/fs_api_connection_setup_notice_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+class MessageThreads::FsApiConnectionSetupNoticeTest < ActionController::TestCase
+  tests MessageThreadsController
+
+  setup do
+    @tenant = tenants(:accountants)
+    @admin = users(:accountants_basic)
+
+    Current.tenant = @tenant
+    Current.user = @admin
+    session[:tenant_id] = @tenant.id
+    session[:user_id] = @admin.id
+    session[:login_expires_at] = Time.current + 1.day
+  end
+
+  teardown do
+    Current.reset
+  end
+
+  test "index shows setup notice for current tenant fs api connection missing username" do
+    connection = Fs::ApiConnection.create!(
+      tenant: @tenant,
+      sub: "missing-username",
+      api_token_private_key: api_connections(:fs_api_connection1).api_token_private_key,
+      settings_password: "password"
+    )
+
+    get :index
+
+    assert_response :success
+    assert_includes @response.body, "Nastavte prepojenie s finančnou správou"
+    assert_includes @response.body, init_admin_tenant_api_connections_fs_api_connection_path(@tenant, connection)
+  end
+
+  test "index shows setup notice for current tenant fs api connection missing password" do
+    connection = Fs::ApiConnection.create!(
+      tenant: @tenant,
+      sub: "missing-password",
+      api_token_private_key: api_connections(:fs_api_connection1).api_token_private_key,
+      settings_username: "username"
+    )
+
+    get :index
+
+    assert_response :success
+    assert_includes @response.body, "Nastavte prepojenie s finančnou správou"
+    assert_includes @response.body, init_admin_tenant_api_connections_fs_api_connection_path(@tenant, connection)
+  end
+
+  test "index does not show setup notice when current tenant fs credentials are configured" do
+    @tenant.api_connections.where(type: "Fs::ApiConnection").each do |connection|
+      connection.update!(settings_username: "username", settings_password: "password")
+    end
+
+    get :index
+
+    assert_response :success
+    assert_not_includes @response.body, "Nastavte prepojenie s finančnou správou"
+  end
+
+  test "index does not show setup notice for non-fs or other tenant missing credentials" do
+    @tenant.api_connections.where(type: "Fs::ApiConnection").each do |connection|
+      connection.update!(settings_username: "username", settings_password: "password")
+    end
+
+    Govbox::ApiConnectionWithOboSupport.create!(
+      tenant: @tenant,
+      sub: "govbox-missing-settings",
+      api_token_private_key: "private_key"
+    )
+
+    other_connection = api_connections(:fs_api_connection2)
+    other_connection.update!(settings_username: nil, settings_password: nil)
+
+    get :index
+
+    assert_response :success
+    assert_not_includes @response.body, "Nastavte prepojenie s finančnou správou"
+    assert_not_includes @response.body, init_admin_tenant_api_connections_fs_api_connection_path(other_connection.tenant, other_connection)
+  end
+end

--- a/test/controllers/message_threads/fs_api_connection_setup_notice_test.rb
+++ b/test/controllers/message_threads/fs_api_connection_setup_notice_test.rb
@@ -29,7 +29,7 @@ class MessageThreads::FsApiConnectionSetupNoticeTest < ActionController::TestCas
     get :index
 
     assert_response :success
-    assert_includes @response.body, "Nastavte prepojenie s finančnou správou"
+    assert_includes @response.body, "Nastavte prihlasovacie údaje pre finančnú správu"
     assert_includes @response.body, init_admin_tenant_api_connections_fs_api_connection_path(@tenant, connection)
   end
 
@@ -44,7 +44,7 @@ class MessageThreads::FsApiConnectionSetupNoticeTest < ActionController::TestCas
     get :index
 
     assert_response :success
-    assert_includes @response.body, "Nastavte prepojenie s finančnou správou"
+    assert_includes @response.body, "Nastavte prihlasovacie údaje pre finančnú správu"
     assert_includes @response.body, init_admin_tenant_api_connections_fs_api_connection_path(@tenant, connection)
   end
 
@@ -56,7 +56,7 @@ class MessageThreads::FsApiConnectionSetupNoticeTest < ActionController::TestCas
     get :index
 
     assert_response :success
-    assert_not_includes @response.body, "Nastavte prepojenie s finančnou správou"
+    assert_not_includes @response.body, "Nastavte prihlasovacie údaje pre finančnú správu"
   end
 
   test "index does not show setup notice for non-fs or other tenant missing credentials" do
@@ -76,7 +76,7 @@ class MessageThreads::FsApiConnectionSetupNoticeTest < ActionController::TestCas
     get :index
 
     assert_response :success
-    assert_not_includes @response.body, "Nastavte prepojenie s finančnou správou"
+    assert_not_includes @response.body, "Nastavte prihlasovacie údaje pre finančnú správu"
     assert_not_includes @response.body, init_admin_tenant_api_connections_fs_api_connection_path(other_connection.tenant, other_connection)
   end
 end


### PR DESCRIPTION
<img width="2800" height="1514" alt="fs-init-current-01-unconfigured-notification" src="https://github.com/user-attachments/assets/fa0ec4f9-0be7-4a58-8a24-1af0c8bd2695" />
<img width="2800" height="1514" alt="fs-init-current-02-configure-form" src="https://github.com/user-attachments/assets/712eacf1-e608-4ee6-aeaf-3380b569aaca" />
<img width="2800" height="1514" alt="fs-init-current-03-success" src="https://github.com/user-attachments/assets/b0030d21-5fdd-4d08-9eb1-064b173f6f84" />
<img width="2800" height="1514" alt="fs-init-current-04-boxify-alert" src="https://github.com/user-attachments/assets/d54b653d-2698-4578-9c82-b868d24a1c7b" />
